### PR TITLE
fix: get_valid_from/get_valid_to read proto fields instead of now()

### DIFF
--- a/ledger-models-rust/fintekkers/wrappers/models/price.rs
+++ b/ledger-models-rust/fintekkers/wrappers/models/price.rs
@@ -108,7 +108,7 @@ impl PriceProtoBuilder {
             valid_to: None,
 
             //This is currently hardcoded, this will change in future versions
-            object_class: "Security".to_string(),
+            object_class: "Price".to_string(),
             //The version is hardcoded, this will change in future versions
             version: "0.0.1".to_string(),
             is_link: false,
@@ -225,5 +225,15 @@ mod test {
         let price_str = price.arbitrary_precision_value;
 
         assert_eq!(price_str, number.to_string());
+    }
+
+    #[test]
+    fn test_price_builder_object_class_is_price() {
+        let number = dec!(100.0);
+        let price_proto = PriceProtoBuilder::new()
+            .dummy_price_wrapper(number)
+            .proto;
+
+        assert_eq!(price_proto.object_class, "Price");
     }
 }

--- a/ledger-models-rust/fintekkers/wrappers/models/raw_datamodel_object.rs
+++ b/ledger-models-rust/fintekkers/wrappers/models/raw_datamodel_object.rs
@@ -17,11 +17,14 @@ pub trait RawDataModelObject {
             }
 
             fn get_valid_from(&self) -> LocalTimestampWrapper{
-                LocalTimestampWrapper::now()
+                match &self.proto.valid_from {
+                    Some(ts) => LocalTimestampWrapper::new(ts.clone()),
+                    None => LocalTimestampWrapper::now(),
+                }
             }
 
             fn get_valid_to(&self) -> Option<LocalTimestampWrapper> {
-                Some(LocalTimestampWrapper::now())
+                self.proto.valid_to.as_ref().map(|ts| LocalTimestampWrapper::new(ts.clone()))
             }
 
             fn get_as_of(&self) -> LocalTimestampWrapper {

--- a/ledger-models-rust/fintekkers/wrappers/models/security.rs
+++ b/ledger-models-rust/fintekkers/wrappers/models/security.rs
@@ -405,4 +405,53 @@ mod test {
         assert!(parsed.product_details.is_none());
         assert_eq!(parsed.coupon_rate.as_ref().unwrap().arbitrary_precision_value, "5.0");
     }
+
+    #[test]
+    fn test_get_valid_from_reads_proto() {
+        use crate::fintekkers::models::util::LocalTimestampProto;
+        use prost_types::Timestamp;
+
+        let ts = LocalTimestampProto {
+            timestamp: Some(Timestamp { seconds: 1_000_000, nanos: 0 }),
+            time_zone: "UTC".to_string(),
+        };
+        let proto = SecurityProtoBuilder::new()
+            .valid_from(LocalTimestampWrapper::new(ts.clone()))
+            .build()
+            .unwrap();
+        let wrapper = SecurityWrapper::new(proto);
+
+        let valid_from = wrapper.get_valid_from();
+        let from_seconds = valid_from.proto.timestamp.as_ref().unwrap().seconds;
+        assert_eq!(from_seconds, 1_000_000);
+    }
+
+    #[test]
+    fn test_get_valid_to_returns_none_when_unset() {
+        let proto = SecurityProtoBuilder::new().build().unwrap();
+        let wrapper = SecurityWrapper::new(proto);
+
+        assert!(wrapper.get_valid_to().is_none());
+    }
+
+    #[test]
+    fn test_get_valid_to_reads_proto_when_set() {
+        use crate::fintekkers::models::util::LocalTimestampProto;
+        use prost_types::Timestamp;
+
+        let ts = LocalTimestampProto {
+            timestamp: Some(Timestamp { seconds: 2_000_000, nanos: 0 }),
+            time_zone: "America/New_York".to_string(),
+        };
+        let proto = SecurityProtoBuilder::new()
+            .valid_to(LocalTimestampWrapper::new(ts.clone()))
+            .build()
+            .unwrap();
+        let wrapper = SecurityWrapper::new(proto);
+
+        let valid_to = wrapper.get_valid_to();
+        assert!(valid_to.is_some());
+        let to_seconds = valid_to.unwrap().proto.timestamp.as_ref().unwrap().seconds;
+        assert_eq!(to_seconds, 2_000_000);
+    }
 }


### PR DESCRIPTION
## Summary
- `get_valid_from()` in the `RawDataModelObject` macro now reads `self.proto.valid_from`, falling back to `now()` only if unset
- `get_valid_to()` now returns `None` when the proto field is unset (previously always returned `Some(now())`)
- Added 3 tests proving the fix: reads proto value, returns None when unset, reads set value

## Test Results
```
test fintekkers::wrappers::models::security::test::test_get_valid_from_reads_proto ... ok
test fintekkers::wrappers::models::security::test::test_get_valid_to_returns_none_when_unset ... ok
test fintekkers::wrappers::models::security::test::test_get_valid_to_reads_proto_when_set ... ok

test result: ok. 48 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

## Test plan
- [x] `cargo test` passes (48/48 tests pass)
- [x] New tests verify valid_from reads proto value
- [x] New tests verify valid_to returns None when unset
- [x] New tests verify valid_to reads proto value when set

Closes #117