### PR TITLE
fix: PriceProtoBuilder object_class corrected from Security to Price

### DIFF
--- a/ledger-models-rust/fintekkers/wrappers/models/price.rs
+++ b/ledger-models-rust/fintekkers/wrappers/models/price.rs
@@ -108,7 +108,7 @@ impl PriceProtoBuilder {
             valid_to: None,
 
             //This is currently hardcoded, this will change in future versions
-            object_class: "Security".to_string(),
+            object_class: "Price".to_string(),
             //The version is hardcoded, this will change in future versions
             version: "0.0.1".to_string(),
             is_link: false,
@@ -225,5 +225,15 @@ mod test {
         let price_str = price.arbitrary_precision_value;
 
         assert_eq!(price_str, number.to_string());
+    }
+
+    #[test]
+    fn test_price_builder_object_class_is_price() {
+        let number = dec!(100.0);
+        let price_proto = PriceProtoBuilder::new()
+            .dummy_price_wrapper(number)
+            .proto;
+
+        assert_eq!(price_proto.object_class, "Price");
     }
 }


### PR DESCRIPTION
## Summary
- `PriceProtoBuilder::new()` hardcoded `object_class` as `"Security"` instead of `"Price"`
- Changed the default to `"Price"`
- Added test `test_price_builder_object_class_is_price` verifying the fix

## Test Results
```
test fintekkers::wrappers::models::price::test::test_price_builder_object_class_is_price ... ok

test result: ok. 46 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

## Test plan
- [x] `cargo test` passes (46/46 tests pass)
- [x] New test verifies object_class is "Price"

Closes #119