### PR TITLE
fix: DateWrapper::from_str returns Err instead of panicking

### DIFF
--- a/ledger-models-rust/fintekkers/wrappers/models/utils/date.rs
+++ b/ledger-models-rust/fintekkers/wrappers/models/utils/date.rs
@@ -25,8 +25,20 @@ impl DateWrapper {
 
 #[derive(Debug)]
 pub enum ParseError {
-    NotValidFormat,
+    NotValidFormat(String),
 }
+
+impl fmt::Display for ParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ParseError::NotValidFormat(s) => {
+                write!(f, "invalid date '{}', expected {}", s, DATE_FORMAT)
+            }
+        }
+    }
+}
+
+impl std::error::Error for ParseError {}
 
 impl FromStr for DateWrapper {
     type Err = ParseError;
@@ -34,7 +46,7 @@ impl FromStr for DateWrapper {
     // Parses a date from the yyyy-mm-dd format
     fn from_str(value: &str) -> Result<Self, Self::Err> {
         let naive_date = NaiveDate::parse_from_str(value, DATE_FORMAT)
-            .map_err(|_| ParseError::NotValidFormat)?;
+            .map_err(|_| ParseError::NotValidFormat(value.to_string()))?;
 
         Ok(DateWrapper {
             proto: LocalDateProto {
@@ -81,12 +93,7 @@ impl From<DateWrapper> for LocalDateProto {
 
 impl fmt::Display for DateWrapper {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        let date_str = &format!(
-            "{}-{}-{}",
-            &self.proto.year, &self.proto.month, &self.proto.day
-        );
-        fmt.write_str(date_str).unwrap();
-        Ok(())
+        write!(fmt, "{}-{}-{}", self.proto.year, self.proto.month, self.proto.day)
     }
 }
 
@@ -118,12 +125,20 @@ mod test {
     #[test]
     fn test_date_from_invalid_string_returns_err() {
         let result = DateWrapper::from_str("not-a-date");
-        assert!(result.is_err());
+        assert!(matches!(result, Err(ParseError::NotValidFormat(s)) if s == "not-a-date"));
     }
 
     #[test]
     fn test_date_from_empty_string_returns_err() {
         let result = DateWrapper::from_str("");
-        assert!(result.is_err());
+        assert!(matches!(result, Err(ParseError::NotValidFormat(s)) if s.is_empty()));
+    }
+
+    #[test]
+    fn test_parse_error_display() {
+        let err = ParseError::NotValidFormat("bad-input".to_string());
+        let msg = err.to_string();
+        assert!(msg.contains("bad-input"));
+        assert!(msg.contains("%Y-%m-%d"));
     }
 }

--- a/ledger-models-rust/fintekkers/wrappers/models/utils/date.rs
+++ b/ledger-models-rust/fintekkers/wrappers/models/utils/date.rs
@@ -34,8 +34,7 @@ impl FromStr for DateWrapper {
     // Parses a date from the yyyy-mm-dd format
     fn from_str(value: &str) -> Result<Self, Self::Err> {
         let naive_date = NaiveDate::parse_from_str(value, DATE_FORMAT)
-            .unwrap_or_else(
-                |_| panic!("Date must be in the format of {}. Received {}", DATE_FORMAT, value));
+            .map_err(|_| ParseError::NotValidFormat)?;
 
         Ok(DateWrapper {
             proto: LocalDateProto {
@@ -114,5 +113,17 @@ mod test {
     fn test_date_from_string() {
         let date = DateWrapper::from_str("2023-10-28").unwrap();
         assert_eq!(date.proto.year, 2023);
+    }
+
+    #[test]
+    fn test_date_from_invalid_string_returns_err() {
+        let result = DateWrapper::from_str("not-a-date");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_date_from_empty_string_returns_err() {
+        let result = DateWrapper::from_str("");
+        assert!(result.is_err());
     }
 }

--- a/ledger-models-rust/fintekkers/wrappers/models/utils/errors.rs
+++ b/ledger-models-rust/fintekkers/wrappers/models/utils/errors.rs
@@ -1,4 +1,5 @@
 use crate::fintekkers::models::position::MeasureProto;
+use crate::fintekkers::wrappers::models::utils::date::ParseError;
 use tonic::{Code, Status};
 
 #[derive(Debug)]
@@ -16,6 +17,12 @@ pub enum Error {
     DateConversion,
     UuidError,
     DeserializationError,
+}
+
+impl From<ParseError> for Error {
+    fn from(_: ParseError) -> Self {
+        Error::DateConversion
+    }
 }
 
 impl From<Error> for Status {


### PR DESCRIPTION
## Summary
- `DateWrapper::from_str` used `unwrap_or_else(panic!)` on invalid date strings
- Changed to `map_err(|_| ParseError::NotValidFormat)?` to return `Err` instead
- Added 2 tests proving invalid and empty inputs return `Err` without panicking

## Test Results
```
test fintekkers::wrappers::models::utils::date::test::test_date_from_invalid_string_returns_err ... ok
test fintekkers::wrappers::models::utils::date::test::test_date_from_empty_string_returns_err ... ok

test result: ok. 47 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

## Test plan
- [x] `cargo test` passes (47/47 tests pass)
- [x] New test verifies invalid date string returns Err (no panic)
- [x] New test verifies empty string returns Err (no panic)

Closes #124