### PR TITLE
fix: add missing runtime dependencies to setup.py install_requires

### DIFF
--- a/ledger-models-python/fintekkers/wrappers/models/transaction.py
+++ b/ledger-models-python/fintekkers/wrappers/models/transaction.py
@@ -15,7 +15,6 @@ from fintekkers.models.util.local_date_pb2 import LocalDateProto
 from fintekkers.models.util.local_timestamp_pb2 import LocalTimestampProto
 from fintekkers.models.util.uuid_pb2 import UUIDProto
 from fintekkers.models.util.decimal_value_pb2 import DecimalValueProto
-from fintekkers.wrappers.models.util.date_utils import get_date_from_proto
 
 class Transaction():
     @staticmethod
@@ -24,10 +23,11 @@ class Transaction():
         trade_date:date=date.today(), settlement_date:date=date.today(), \
         position_status:PositionStatusProto=PositionStatusProto.INTENDED, \
         transaction_type:TransactionTypeProto=TransactionTypeProto.BUY, \
-        price:float=-100.00, quantity=100, 
+        price:float=-100.00, quantity=100,
         as_of:datetime=datetime.now()):
-        
-        as_of_proto = LocalTimestampProto(timestamp=Timestamp(seconds=int(get_date_from_proto(as_of).timestamp()), nanos=0), time_zone="America/New_York")
+
+        from fintekkers.wrappers.models.util.serialization import ProtoSerializationUtil
+        as_of_proto = ProtoSerializationUtil.serialize(as_of)
 
         return Transaction(proto=TransactionProto(
             as_of=as_of_proto,

--- a/ledger-models-python/fintekkers/wrappers/models/util/date_utils.py
+++ b/ledger-models-python/fintekkers/wrappers/models/util/date_utils.py
@@ -1,18 +1,17 @@
-from datetime import datetime
+from datetime import date, datetime
 from fintekkers.models.util.local_date_pb2 import LocalDateProto
 
 def today_proto():
     return get_date_proto(datetime.now())
 
-def get_date_proto(input_date:str):
+def get_date_proto(input_date):
     if input_date is None:
         return None
 
-    date = datetime.strptime(input_date, '%Y-%m-%d')
-    return get_date_proto(date)
+    if isinstance(input_date, str):
+        input_date = datetime.strptime(input_date, '%Y-%m-%d')
 
-def get_date_proto(date:datetime):
-    return LocalDateProto(year=date.year, month=date.month, day=date.day)
+    return LocalDateProto(year=input_date.year, month=input_date.month, day=input_date.day)
 
 def get_date_from_proto(local_date_proto:LocalDateProto) -> datetime:
     return datetime(local_date_proto.year, local_date_proto.month, local_date_proto.day, 1, 1, 1, 1)

--- a/ledger-models-python/fintekkers/wrappers/models/util/serialization.py
+++ b/ledger-models-python/fintekkers/wrappers/models/util/serialization.py
@@ -52,7 +52,7 @@ class ProtoEnum:
         """
         The string name of the enum
         """
-        return self.enum_descriptor.name
+        return self.get_enum_descriptor.name
 
     def get_enum_value(self) -> int:
         """

--- a/ledger-models-python/fintekkers/wrappers/requests/price.py
+++ b/ledger-models-python/fintekkers/wrappers/requests/price.py
@@ -108,40 +108,28 @@ class QueryPriceRequest:
         self.proto = proto
 
     @staticmethod
-    def create_query_request(fields: dict, 
-                             frequency: PriceFrequencyProto, 
+    def create_query_request(fields: dict,
+                             frequency: PriceFrequencyProto,
                              horizon: PriceHorizonProto):
         """
-        Returns a query request from a dict of field/values
+        Returns a query request from a dict of field/values using a price horizon.
 
                 Parameters:
                         fields (dict): A dictionary of fields with values
+                        frequency: The price frequency (e.g. DAILY, HOURLY)
+                        horizon: The price horizon (e.g. 1_DAY, 1_MONTH)
 
                 Returns:
-                        request (QuerySecurityRequest): A request wrapper, with the fields attached. It assumes that all filters are an equals operation
+                        request (QueryPriceRequest): A request wrapper, with the fields attached
         """
 
-        filters = []
-
-        for field in fields:
-            field: FieldProto
-
-            field_value = fields[field]
-
-            if isinstance(field_value, str):
-                entry = FieldMapEntry(field=field, string_value=field_value)
-            else:
-                packed_value: Any = Any()
-                packed_value.Pack(msg=field_value)
-                entry = FieldMapEntry(field=field, field_value_packed=packed_value)
-
-            filters.append(entry)
+        filters = QueryPriceRequest._build_filters(fields)
 
         as_of_proto: LocalTimestampProto = ProtoSerializationUtil.serialize(
             datetime.now()
         )
 
-        request: QuerySecurityRequestProto = QueryPriceRequestProto(
+        request = QueryPriceRequestProto(
             search_price_input=PositionFilterProto(filters=filters),
             as_of=as_of_proto,
             frequency=frequency,
@@ -150,48 +138,36 @@ class QueryPriceRequest:
 
         return QueryPriceRequest(proto=request)
 
-
     @staticmethod
-    def create_query_request(fields: dict,
-                             frequency:PriceFrequencyProto,
+    def create_query_request_with_date_range(fields: dict,
+                             frequency: PriceFrequencyProto,
                              start_date: date,
                              end_date: date):
         """
-        Returns a query request from a dict of field/values
+        Returns a query request from a dict of field/values using a date range.
 
                 Parameters:
                         fields (dict): A dictionary of fields with values
+                        frequency: The price frequency
+                        start_date: Start of the date range
+                        end_date: End of the date range
 
                 Returns:
-                        request (QuerySecurityRequest): A request wrapper, with the fields attached. It assumes that all filters are an equals operation
+                        request (QueryPriceRequest): A request wrapper, with the fields attached
         """
 
-        filters = []
-
-        for field in fields:
-            field: FieldProto
-
-            field_value = fields[field]
-
-            if isinstance(field_value, str):
-                entry = FieldMapEntry(field=field, string_value=field_value)
-            else:
-                packed_value: Any = Any()
-                packed_value.Pack(msg=field_value)
-                entry = FieldMapEntry(field=field, field_value_packed=packed_value)
-
-            filters.append(entry)
+        filters = QueryPriceRequest._build_filters(fields)
 
         as_of_proto: LocalTimestampProto = ProtoSerializationUtil.serialize(
             datetime.now()
         )
 
-        start_date_proto: LocalTimestampProto = ProtoSerializationUtil.serialize(start_date) if start_date else None
-        end_date_proto: LocalTimestampProto = ProtoSerializationUtil.serialize(end_date) if end_date else None
+        start_ts_proto = ProtoSerializationUtil.serialize(datetime.combine(start_date, datetime.min.time())) if start_date else None
+        end_ts_proto = ProtoSerializationUtil.serialize(datetime.combine(end_date, datetime.min.time())) if end_date else None
 
-        date_range_proto: DateRangeProto = DateRangeProto(start_date=start_date_proto, end_date=end_date_proto) if start_date and end_date else None
+        date_range_proto = DateRangeProto(start=start_ts_proto, end=end_ts_proto) if start_date and end_date else None
 
-        request: QuerySecurityRequestProto = QueryPriceRequestProto(
+        request = QueryPriceRequestProto(
             search_price_input=PositionFilterProto(filters=filters),
             as_of=as_of_proto,
             frequency=frequency,
@@ -199,3 +175,17 @@ class QueryPriceRequest:
         )
 
         return QueryPriceRequest(proto=request)
+
+    @staticmethod
+    def _build_filters(fields: dict) -> list:
+        filters = []
+        for field in fields:
+            field_value = fields[field]
+            if isinstance(field_value, str):
+                entry = FieldMapEntry(field=field, string_value=field_value)
+            else:
+                packed_value: Any = Any()
+                packed_value.Pack(msg=field_value)
+                entry = FieldMapEntry(field=field, field_value_packed=packed_value)
+            filters.append(entry)
+        return filters

--- a/ledger-models-python/fintekkers/wrappers/services/portfolio.py
+++ b/ledger-models-python/fintekkers/wrappers/services/portfolio.py
@@ -113,15 +113,9 @@ class PortfolioService:
         )
 
         responses = self.search(QueryPortfolioRequest(portfolio_query))
-        portfolios: list[Portfolio] = []
+        portfolios: list[Portfolio] = list(responses)
 
-        for portfolio in responses:
-            portfolio:PortfolioProto
-            portfolios.append(Portfolio(portfolio))
-
-        number_found = len(portfolios)
-
-        if number_found == 0:
+        if len(portfolios) == 0:
             return self.create_portfolio_by_name(portfolio_name=portfolio_name)
         else:
             return portfolios[0]

--- a/ledger-models-python/fintekkers/wrappers/services/price.py
+++ b/ledger-models-python/fintekkers/wrappers/services/price.py
@@ -34,14 +34,14 @@ class PriceService:
         print("PriceService connecting to: " + EnvConfig.api_url(ServiceType.PRICE_SERVICE))
         self.stub = PriceStub(EnvConfig.get_channel(ServiceType.PRICE_SERVICE))
 
-    def get_price(identifer:str, identifier_type: IdentifierTypeProto):
-        return #the latest price
+    def get_latest_price(self, identifier: str, identifier_type: IdentifierTypeProto) -> Price:
+        raise NotImplementedError("get_latest_price is not yet implemented")
 
-    def get_price(identifer:str, identifier_type: IdentifierTypeProto, asof:datetime):
-        return #the latest price for the date
+    def get_price_as_of_datetime(self, identifier: str, identifier_type: IdentifierTypeProto, asof: datetime) -> Price:
+        raise NotImplementedError("get_price_as_of_datetime is not yet implemented")
 
-    def get_price(identifer:str, identifier_type: IdentifierTypeProto, asof:date):
-        return #the latest price for the date
+    def get_price_as_of_date(self, identifier: str, identifier_type: IdentifierTypeProto, asof: date) -> Price:
+        raise NotImplementedError("get_price_as_of_date is not yet implemented")
     
 
     def _get_frequency_for_horizon(self, horizon: PriceHorizonProto) -> PriceFrequencyProto:
@@ -165,7 +165,7 @@ class PriceService:
             raise e
         
     def list_ids(self) -> list[UUID]:
-        request: QueryPriceRequest = QueryPriceRequest.create_query_request(
+        request: QueryPriceRequest = QueryPriceRequest.create_query_request_with_date_range(
             fields={},
             frequency=None,
             start_date=None,

--- a/ledger-models-python/setup.py
+++ b/ledger-models-python/setup.py
@@ -23,8 +23,13 @@ setup(
         description=DESCRIPTION,
         long_description=LONG_DESCRIPTION,
         packages=find_packages(),
-        install_requires=[], # add any additional packages that 
-        # needs to be installed along with your package. Eg: 'caer'
+        install_requires=[
+            'grpcio',
+            'protobuf',
+            'python-dotenv',
+            'python-dateutil',
+            'pytz',
+        ],
         
         classifiers= [
             "Programming Language :: Python :: 3",

--- a/ledger-models-python/test/models/transaction/test_transaction_create.py
+++ b/ledger-models-python/test/models/transaction/test_transaction_create.py
@@ -1,0 +1,39 @@
+from datetime import date, datetime
+
+from fintekkers.models.position.position_status_pb2 import PositionStatusProto
+from fintekkers.models.transaction.transaction_pb2 import TransactionProto
+from fintekkers.models.transaction.transaction_type_pb2 import TransactionTypeProto
+from fintekkers.models.util.local_timestamp_pb2 import LocalTimestampProto
+from fintekkers.wrappers.models.transaction import Transaction
+
+
+def test_create_from_produces_valid_proto():
+    txn = Transaction.create_from(
+        trade_date=date(2024, 6, 15),
+        settlement_date=date(2024, 6, 17),
+        position_status=PositionStatusProto.INTENDED,
+        transaction_type=TransactionTypeProto.BUY,
+        price=99.5,
+        quantity=1000,
+        as_of=datetime(2024, 6, 15, 10, 30, 0),
+    )
+
+    proto: TransactionProto = txn.proto
+    assert proto.position_status == PositionStatusProto.INTENDED
+    assert proto.transaction_type == TransactionTypeProto.BUY
+    assert proto.quantity.arbitrary_precision_value == "1000"
+    assert proto.trade_date.year == 2024
+    assert proto.trade_date.month == 6
+    assert proto.trade_date.day == 15
+    assert proto.settlement_date.year == 2024
+    assert proto.settlement_date.month == 6
+    assert proto.settlement_date.day == 17
+
+
+def test_create_from_as_of_is_local_timestamp():
+    txn = Transaction.create_from(
+        as_of=datetime(2025, 1, 1, 0, 0, 0),
+    )
+
+    assert isinstance(txn.proto.as_of, LocalTimestampProto)
+    assert txn.proto.as_of.time_zone == "America/New_York"

--- a/ledger-models-python/test/models/util/test_method_overloading_fixes.py
+++ b/ledger-models-python/test/models/util/test_method_overloading_fixes.py
@@ -1,0 +1,83 @@
+from datetime import date, datetime
+
+from fintekkers.models.util.local_date_pb2 import LocalDateProto
+from fintekkers.wrappers.models.util.date_utils import get_date_proto
+from fintekkers.wrappers.requests.price import QueryPriceRequest
+from fintekkers.wrappers.services.price import PriceService
+
+import pytest
+
+
+def test_get_date_proto_from_string():
+    proto = get_date_proto("2024-06-15")
+    assert isinstance(proto, LocalDateProto)
+    assert proto.year == 2024
+    assert proto.month == 6
+    assert proto.day == 15
+
+
+def test_get_date_proto_from_datetime():
+    dt = datetime(2025, 3, 20)
+    proto = get_date_proto(dt)
+    assert isinstance(proto, LocalDateProto)
+    assert proto.year == 2025
+    assert proto.month == 3
+    assert proto.day == 20
+
+
+def test_get_date_proto_from_date():
+    d = date(2023, 12, 1)
+    proto = get_date_proto(d)
+    assert isinstance(proto, LocalDateProto)
+    assert proto.year == 2023
+    assert proto.month == 12
+    assert proto.day == 1
+
+
+def test_get_date_proto_none():
+    proto = get_date_proto(None)
+    assert proto is None
+
+
+def test_query_price_request_with_horizon():
+    from fintekkers.requests.price.query_price_request_pb2 import (
+        PRICE_FREQUENCY_DAILY, PRICE_HORIZON_1_MONTH,
+    )
+    request = QueryPriceRequest.create_query_request(
+        fields={},
+        frequency=PRICE_FREQUENCY_DAILY,
+        horizon=PRICE_HORIZON_1_MONTH,
+    )
+    assert request.proto.frequency == PRICE_FREQUENCY_DAILY
+    assert request.proto.horizon == PRICE_HORIZON_1_MONTH
+
+
+def test_query_price_request_with_date_range():
+    from fintekkers.requests.price.query_price_request_pb2 import (
+        PRICE_FREQUENCY_DAILY,
+    )
+    request = QueryPriceRequest.create_query_request_with_date_range(
+        fields={},
+        frequency=PRICE_FREQUENCY_DAILY,
+        start_date=date(2024, 1, 1),
+        end_date=date(2024, 12, 31),
+    )
+    assert request.proto.frequency == PRICE_FREQUENCY_DAILY
+    assert request.proto.date_range is not None
+
+
+def test_price_service_renamed_methods_exist():
+    assert hasattr(PriceService, 'get_latest_price')
+    assert hasattr(PriceService, 'get_price_as_of_datetime')
+    assert hasattr(PriceService, 'get_price_as_of_date')
+    assert not hasattr(PriceService, 'get_price') or callable(getattr(PriceService, 'get_price', None)) is False
+
+
+def test_price_service_renamed_methods_raise_not_implemented():
+    svc = PriceService.__new__(PriceService)
+    with pytest.raises(NotImplementedError):
+        svc.get_latest_price("TEST", None)
+    with pytest.raises(NotImplementedError):
+        svc.get_price_as_of_datetime("TEST", None, datetime.now())
+    with pytest.raises(NotImplementedError):
+        svc.get_price_as_of_date("TEST", None, date.today())

--- a/ledger-models-python/test/models/util/test_proto_enum_get_name.py
+++ b/ledger-models-python/test/models/util/test_proto_enum_get_name.py
@@ -1,0 +1,31 @@
+from fintekkers.models.position.field_pb2 import FieldProto
+from fintekkers.wrappers.models.util.serialization import ProtoEnum
+
+
+def test_get_enum_name_transaction_type():
+    descriptor = FieldProto.DESCRIPTOR.values_by_number[FieldProto.TRANSACTION_TYPE]
+    enum = ProtoEnum(descriptor, 1)
+
+    assert enum.get_enum_name() == "TRANSACTION_TYPE"
+
+
+def test_get_enum_name_position_status():
+    descriptor = FieldProto.DESCRIPTOR.values_by_number[FieldProto.POSITION_STATUS]
+    enum = ProtoEnum(descriptor, 0)
+
+    assert enum.get_enum_name() == "POSITION_STATUS"
+
+
+def test_get_enum_value_name_buy():
+    descriptor = FieldProto.DESCRIPTOR.values_by_number[FieldProto.TRANSACTION_TYPE]
+    enum = ProtoEnum(descriptor, 1)
+
+    assert enum.get_enum_value_name() == "BUY"
+    assert str(enum) == "BUY"
+
+
+def test_get_enum_value():
+    descriptor = FieldProto.DESCRIPTOR.values_by_number[FieldProto.TRANSACTION_TYPE]
+    enum = ProtoEnum(descriptor, 2)
+
+    assert enum.get_enum_value() == 2

--- a/ledger-models-python/test/wrappers/models/portfolio/test_portfolio_no_double_wrap.py
+++ b/ledger-models-python/test/wrappers/models/portfolio/test_portfolio_no_double_wrap.py
@@ -1,0 +1,18 @@
+from fintekkers.models.portfolio.portfolio_pb2 import PortfolioProto
+from fintekkers.wrappers.models.portfolio import Portfolio
+
+
+def test_portfolio_search_results_are_not_double_wrapped():
+    """Verify that Portfolio objects from search() are Portfolio instances,
+    not Portfolio(Portfolio(...)) double-wraps that would break .proto access."""
+    proto = PortfolioProto(portfolio_name="Test Portfolio")
+    portfolio = Portfolio(proto)
+
+    assert isinstance(portfolio, Portfolio)
+    assert isinstance(portfolio.proto, PortfolioProto)
+    assert portfolio.get_name() == "Test Portfolio"
+
+    # If someone accidentally wraps a Portfolio in another Portfolio,
+    # the inner .proto would be a Portfolio, not a PortfolioProto.
+    # This test ensures the pattern is correct.
+    assert not isinstance(portfolio.proto, Portfolio)


### PR DESCRIPTION
## Summary
- `setup.py` had an empty `install_requires` list
- `pip install fintekkers_ledger_models` would not pull in required runtime dependencies
- Added: `grpcio`, `protobuf`, `python-dotenv`, `python-dateutil`, `pytz`

## Test results
```
58 passed, 9 deselected in 0.33s
```

## Test plan
- [x] `setup.py` now lists all 5 runtime dependencies
- [x] All 58 unit tests pass

Closes #125