### PR TITLE
fix: implement TransactionSet.allLatestTransactions and BondPrice.getCleanPrice

### DIFF
--- a/ledger-models-java/src/main/java/common/models/price/BondPrice.java
+++ b/ledger-models-java/src/main/java/common/models/price/BondPrice.java
@@ -33,7 +33,12 @@ public class BondPrice extends Price {
     }
 
     public BigDecimal getCleanPrice() {
-        throw new RuntimeException("Not supported yet");
+        if (accruedInterest == null) {
+            throw new UnsupportedOperationException(
+                    "Clean price is unavailable because this BondPrice was constructed from a dirty price only. " +
+                    "Use the constructor that accepts both cleanPrice and accruedInterest.");
+        }
+        return getDirtyPrice().subtract(accruedInterest);
     }
 
     public BigDecimal getAccruedInterest() {

--- a/ledger-models-java/src/main/java/common/models/price/BondPrice.java
+++ b/ledger-models-java/src/main/java/common/models/price/BondPrice.java
@@ -42,8 +42,10 @@ public class BondPrice extends Price {
     }
 
     public BigDecimal getAccruedInterest() {
-        if(this.accruedInterest == null)
-            throw new RuntimeException("This price was created from a dirty price and accrued interest was not provided");
+        if (this.accruedInterest == null)
+            throw new UnsupportedOperationException(
+                    "Accrued interest is unavailable because this BondPrice was constructed from a dirty price only. " +
+                    "Use the constructor that accepts both cleanPrice and accruedInterest.");
 
         return this.accruedInterest;
     }

--- a/ledger-models-java/src/main/java/common/models/transaction/TransactionSet.java
+++ b/ledger-models-java/src/main/java/common/models/transaction/TransactionSet.java
@@ -17,8 +17,18 @@ public class TransactionSet extends HashMap<UUID, List<Transaction>> {
     public List<Transaction> allLatestTransactions() {
         List<Transaction> transactions = new ArrayList<>();
 
-        if(true)
-            throw new RuntimeException("Not impleented");
+        for (List<Transaction> versions : values()) {
+            if (versions.isEmpty()) continue;
+
+            Transaction latest = versions.get(0);
+            for (int i = 1; i < versions.size(); i++) {
+                Transaction candidate = versions.get(i);
+                if (candidate.getAsOf().isAfter(latest.getAsOf())) {
+                    latest = candidate;
+                }
+            }
+            transactions.add(latest);
+        }
 
         return transactions;
     }

--- a/ledger-models-java/src/test/java/common/models/price/BondPriceTest.java
+++ b/ledger-models-java/src/test/java/common/models/price/BondPriceTest.java
@@ -1,0 +1,73 @@
+package common.models.price;
+
+import common.models.security.CashSecurity;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.ZonedDateTime;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class BondPriceTest {
+
+    @Test
+    void getCleanPrice_returnsCleanWhenAccruedInterestProvided() {
+        BigDecimal cleanPrice = new BigDecimal("99.50");
+        BigDecimal accruedInterest = new BigDecimal("1.25");
+
+        BondPrice bondPrice = new BondPrice(UUID.randomUUID(), cleanPrice, accruedInterest,
+                CashSecurity.USD, ZonedDateTime.now());
+
+        assertEquals(new BigDecimal("99.50"), bondPrice.getCleanPrice());
+    }
+
+    @Test
+    void getDirtyPrice_equalsCleanPlusAccrued() {
+        BigDecimal cleanPrice = new BigDecimal("99.50");
+        BigDecimal accruedInterest = new BigDecimal("1.25");
+
+        BondPrice bondPrice = new BondPrice(UUID.randomUUID(), cleanPrice, accruedInterest,
+                CashSecurity.USD, ZonedDateTime.now());
+
+        assertEquals(new BigDecimal("100.75"), bondPrice.getDirtyPrice());
+    }
+
+    @Test
+    void getCleanPrice_throwsWhenConstructedFromDirtyPriceOnly() {
+        BigDecimal dirtyPrice = new BigDecimal("100.75");
+
+        BondPrice bondPrice = new BondPrice(UUID.randomUUID(), dirtyPrice,
+                CashSecurity.USD, ZonedDateTime.now());
+
+        UnsupportedOperationException ex = assertThrows(
+                UnsupportedOperationException.class,
+                bondPrice::getCleanPrice);
+
+        assertTrue(ex.getMessage().contains("dirty price only"));
+    }
+
+    @Test
+    void getAccruedInterest_returnsValueWhenProvided() {
+        BigDecimal cleanPrice = new BigDecimal("99.50");
+        BigDecimal accruedInterest = new BigDecimal("1.25");
+
+        BondPrice bondPrice = new BondPrice(UUID.randomUUID(), cleanPrice, accruedInterest,
+                CashSecurity.USD, ZonedDateTime.now());
+
+        assertEquals(new BigDecimal("1.25"), bondPrice.getAccruedInterest());
+    }
+
+    @Test
+    void factoryMethod_withCleanAndAccrued() {
+        BigDecimal cleanPrice = new BigDecimal("98.00");
+        BigDecimal accruedInterest = new BigDecimal("0.75");
+
+        BondPrice bondPrice = BondPrice.getPrice(cleanPrice, accruedInterest,
+                CashSecurity.USD, ZonedDateTime.now());
+
+        assertEquals(new BigDecimal("98.00"), bondPrice.getCleanPrice());
+        assertEquals(new BigDecimal("98.75"), bondPrice.getDirtyPrice());
+    }
+}

--- a/ledger-models-java/src/test/java/common/models/price/BondPriceTest.java
+++ b/ledger-models-java/src/test/java/common/models/price/BondPriceTest.java
@@ -12,6 +12,11 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class BondPriceTest {
 
+    private static void assertBigDecimalEquals(BigDecimal expected, BigDecimal actual) {
+        assertEquals(0, expected.compareTo(actual),
+                () -> "Expected " + expected + " but was " + actual);
+    }
+
     @Test
     void getCleanPrice_returnsCleanWhenAccruedInterestProvided() {
         BigDecimal cleanPrice = new BigDecimal("99.50");
@@ -20,7 +25,7 @@ class BondPriceTest {
         BondPrice bondPrice = new BondPrice(UUID.randomUUID(), cleanPrice, accruedInterest,
                 CashSecurity.USD, ZonedDateTime.now());
 
-        assertEquals(new BigDecimal("99.50"), bondPrice.getCleanPrice());
+        assertBigDecimalEquals(new BigDecimal("99.50"), bondPrice.getCleanPrice());
     }
 
     @Test
@@ -31,7 +36,7 @@ class BondPriceTest {
         BondPrice bondPrice = new BondPrice(UUID.randomUUID(), cleanPrice, accruedInterest,
                 CashSecurity.USD, ZonedDateTime.now());
 
-        assertEquals(new BigDecimal("100.75"), bondPrice.getDirtyPrice());
+        assertBigDecimalEquals(new BigDecimal("100.75"), bondPrice.getDirtyPrice());
     }
 
     @Test
@@ -56,7 +61,21 @@ class BondPriceTest {
         BondPrice bondPrice = new BondPrice(UUID.randomUUID(), cleanPrice, accruedInterest,
                 CashSecurity.USD, ZonedDateTime.now());
 
-        assertEquals(new BigDecimal("1.25"), bondPrice.getAccruedInterest());
+        assertBigDecimalEquals(new BigDecimal("1.25"), bondPrice.getAccruedInterest());
+    }
+
+    @Test
+    void getAccruedInterest_throwsWhenConstructedFromDirtyPriceOnly() {
+        BigDecimal dirtyPrice = new BigDecimal("100.75");
+
+        BondPrice bondPrice = new BondPrice(UUID.randomUUID(), dirtyPrice,
+                CashSecurity.USD, ZonedDateTime.now());
+
+        UnsupportedOperationException ex = assertThrows(
+                UnsupportedOperationException.class,
+                bondPrice::getAccruedInterest);
+
+        assertTrue(ex.getMessage().contains("dirty price only"));
     }
 
     @Test
@@ -67,7 +86,7 @@ class BondPriceTest {
         BondPrice bondPrice = BondPrice.getPrice(cleanPrice, accruedInterest,
                 CashSecurity.USD, ZonedDateTime.now());
 
-        assertEquals(new BigDecimal("98.00"), bondPrice.getCleanPrice());
-        assertEquals(new BigDecimal("98.75"), bondPrice.getDirtyPrice());
+        assertBigDecimalEquals(new BigDecimal("98.00"), bondPrice.getCleanPrice());
+        assertBigDecimalEquals(new BigDecimal("98.75"), bondPrice.getDirtyPrice());
     }
 }

--- a/ledger-models-java/src/test/java/common/models/transaction/TransactionSetTest.java
+++ b/ledger-models-java/src/test/java/common/models/transaction/TransactionSetTest.java
@@ -1,0 +1,89 @@
+package common.models.transaction;
+
+import common.models.portfolio.Portfolio;
+import common.models.price.Price;
+import common.models.security.Security;
+import common.models.security.CashSecurity;
+import common.models.strategy.StrategyAllocation;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class TransactionSetTest {
+
+    private Transaction createTransaction(UUID id, ZonedDateTime asOf) {
+        Portfolio portfolio = new Portfolio(UUID.randomUUID(), "Test Portfolio", ZonedDateTime.now());
+        Security security = testutil.DummyEquityObjects.getDummySecurity();
+        Price price = Price.getPrice(BigDecimal.TEN, security);
+
+        return new Transaction(id, portfolio, price,
+                LocalDate.now(), LocalDate.now().plusDays(2),
+                BigDecimal.TEN, security, TransactionType.BUY,
+                new StrategyAllocation(UUID.randomUUID(), ZonedDateTime.now()),
+                asOf, null, "", null);
+    }
+
+    @Test
+    void allLatestTransactions_returnsSingleVersionPerUUID() {
+        TransactionSet set = new TransactionSet();
+
+        UUID txnId = UUID.randomUUID();
+        ZonedDateTime earlier = ZonedDateTime.now().minusHours(2);
+        ZonedDateTime later = ZonedDateTime.now();
+
+        Transaction v1 = createTransaction(txnId, earlier);
+        Transaction v2 = createTransaction(txnId, later);
+
+        set.addTransaction(v1);
+        set.addTransaction(v2);
+
+        List<Transaction> latest = set.allLatestTransactions();
+
+        assertEquals(1, latest.size());
+        assertEquals(later, latest.get(0).getAsOf());
+    }
+
+    @Test
+    void allLatestTransactions_multipleUUIDs() {
+        TransactionSet set = new TransactionSet();
+
+        UUID id1 = UUID.randomUUID();
+        UUID id2 = UUID.randomUUID();
+        ZonedDateTime now = ZonedDateTime.now();
+
+        set.addTransaction(createTransaction(id1, now.minusHours(1)));
+        set.addTransaction(createTransaction(id1, now));
+        set.addTransaction(createTransaction(id2, now));
+
+        List<Transaction> latest = set.allLatestTransactions();
+
+        assertEquals(2, latest.size());
+    }
+
+    @Test
+    void allLatestTransactions_emptySet() {
+        TransactionSet set = new TransactionSet();
+        List<Transaction> latest = set.allLatestTransactions();
+        assertTrue(latest.isEmpty());
+    }
+
+    @Test
+    void allLatestTransactions_singleVersion() {
+        TransactionSet set = new TransactionSet();
+
+        UUID id = UUID.randomUUID();
+        Transaction txn = createTransaction(id, ZonedDateTime.now());
+        set.addTransaction(txn);
+
+        List<Transaction> latest = set.allLatestTransactions();
+        assertEquals(1, latest.size());
+        assertSame(txn, latest.get(0));
+    }
+}


### PR DESCRIPTION
## Summary
- **TransactionSet.allLatestTransactions()**: Fixed typo ("Not impleented") and implemented the method. Closes #126
- **BondPrice.getCleanPrice()**: Implemented clean price = dirty price - accrued interest. Closes #127

## Changes
- `TransactionSet.java`: implemented `allLatestTransactions()` 
- `BondPrice.java`: implemented `getCleanPrice()` from dirty price minus accrued interest
- Added `TransactionSetTest.java` and `BondPriceTest.java`

## Found by
Cross-language implementation review (REVIEW-001)