### PR TITLE
Phase 2: Euro government bonds (Bunds, OATs)

### DIFF
--- a/valuation-calculator-rust/src/bond/accrued_interest.rs
+++ b/valuation-calculator-rust/src/bond/accrued_interest.rs
@@ -74,4 +74,44 @@ mod tests {
         let expected = 2.5 * 183.0 / 184.0;
         assert!((ai - expected).abs() < 1e-10);
     }
+
+    // ── Euro bond (annual coupon) tests ─────────────────────────────
+
+    fn euro_bond() -> BondSpec {
+        BondSpec {
+            coupon_rate: 0.025,
+            coupon_freq: 1,
+            coupon_type: CouponType::Fixed,
+            face_value: 100.0,
+            dated_date: d(2024, 7, 4),
+            maturity_date: d(2034, 7, 4),
+            day_count: DayCountConvention::ActualActualICMA,
+        }
+    }
+
+    #[test]
+    fn euro_zero_on_coupon_date() {
+        assert!((accrued_interest(&euro_bond(), d(2025, 7, 4))).abs() < 1e-15);
+    }
+
+    #[test]
+    fn euro_accrued_mid_period() {
+        // Annual coupon = 2.5% × 100 = 2.50
+        // Settle 2025-01-04, last coupon 2024-07-04, next 2025-07-04
+        // days accrued = 184, days in period = 365 or 366
+        let ai = accrued_interest(&euro_bond(), d(2025, 1, 4));
+        let last = d(2024, 7, 4);
+        let next = d(2025, 7, 4);
+        let settle = d(2025, 1, 4);
+        let expected = 2.5 * (settle.days_since(&last) as f64) / (next.days_since(&last) as f64);
+        assert!((ai - expected).abs() < 1e-10, "Euro AI={}, expected={}", ai, expected);
+    }
+
+    #[test]
+    fn euro_full_annual_coupon() {
+        // Annual coupon is larger than semiannual
+        let ai_euro = accrued_interest(&euro_bond(), d(2025, 1, 4));
+        // Semiannual with same rate would accrue half the coupon over half the period
+        assert!(ai_euro > 1.0, "Annual AI should be meaningful: {}", ai_euro);
+    }
 }

--- a/valuation-calculator-rust/src/bond/cashflows.rs
+++ b/valuation-calculator-rust/src/bond/cashflows.rs
@@ -147,4 +147,64 @@ mod tests {
         assert_eq!(non_zero.len(), 1);
         assert!((non_zero[0].amount - 100.0).abs() < 1e-12);
     }
+
+    // ── Euro bond (annual coupon) tests ─────────────────────────────
+
+    fn euro_bond(coupon: f64, dated: Date, maturity: Date) -> BondSpec {
+        BondSpec {
+            coupon_rate: coupon,
+            coupon_freq: 1,
+            coupon_type: CouponType::Fixed,
+            face_value: 100.0,
+            dated_date: dated,
+            maturity_date: maturity,
+            day_count: DayCountConvention::ActualActualICMA,
+        }
+    }
+
+    #[test]
+    fn euro_coupon_dates_10y() {
+        let bond = euro_bond(0.025, d(2025, 2, 15), d(2035, 2, 15));
+        let dates = generate_coupon_dates(&bond);
+        assert_eq!(dates.first(), Some(&d(2025, 2, 15)));
+        assert_eq!(dates.last(), Some(&d(2035, 2, 15)));
+        assert_eq!(dates.len(), 11); // dated_date + 10 annual coupons
+    }
+
+    #[test]
+    fn euro_cashflows_on_coupon_date() {
+        let bond = euro_bond(0.03, d(2025, 1, 4), d(2030, 1, 4));
+        let cfs = generate(&bond, d(2025, 1, 4));
+        assert_eq!(cfs.len(), 5); // 5 annual coupons
+        assert!((cfs[0].amount - 3.0).abs() < 1e-12); // 3% × 100 / 1
+        assert!((cfs[4].amount - 103.0).abs() < 1e-12); // last = coupon + principal
+        assert!((cfs[0].period_fraction - 1.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn euro_cashflows_between_coupon_dates() {
+        // Bund: 2.5% coupon, annual, settle between dates
+        let bond = euro_bond(0.025, d(2024, 7, 4), d(2034, 7, 4));
+        let settle = d(2025, 3, 15);
+        let cfs = generate(&bond, settle);
+        assert_eq!(cfs.len(), 10); // 10 remaining annual payments
+
+        // First cashflow should be at 2025-07-04
+        assert_eq!(cfs[0].date, d(2025, 7, 4));
+
+        // w = days(Mar15, Jul4) / days(Jul4_2024, Jul4_2025)
+        let prev = d(2024, 7, 4);
+        let next = d(2025, 7, 4);
+        let expected_w = (next.days_since(&settle) as f64) / (next.days_since(&prev) as f64);
+        assert!((cfs[0].period_fraction - expected_w).abs() < 1e-10,
+            "w={}, expected={}", cfs[0].period_fraction, expected_w);
+    }
+
+    #[test]
+    fn euro_coupon_amount_annual() {
+        // Annual coupon = coupon_rate × face_value / 1
+        let bond = euro_bond(0.0175, d(2025, 5, 15), d(2035, 5, 15));
+        let cfs = generate(&bond, d(2025, 5, 15));
+        assert!((cfs[0].amount - 1.75).abs() < 1e-12);
+    }
 }

--- a/valuation-calculator-rust/src/bond/duration.rs
+++ b/valuation-calculator-rust/src/bond/duration.rs
@@ -109,4 +109,75 @@ mod tests {
         let dur = macaulay_duration(&bond, 0.047, d(2025, 5, 15));
         assert!(dur > 14.0 && dur < 20.0, "30Y duration={}", dur);
     }
+
+    // ── Euro bond (annual coupon) tests ─────────────────────────────
+
+    fn euro_bond(coupon: f64, maturity: Date) -> BondSpec {
+        BondSpec {
+            coupon_rate: coupon, coupon_freq: 1, coupon_type: CouponType::Fixed,
+            face_value: 100.0, dated_date: d(2025, 2, 15), maturity_date: maturity,
+            day_count: DayCountConvention::ActualActualICMA,
+        }
+    }
+
+    #[test]
+    fn euro_modified_equals_macaulay_divided_by_1_plus_y() {
+        // For annual bonds: mod_dur = mac_dur / (1 + y) — not (1 + y/2)
+        let bond = euro_bond(0.025, d(2035, 2, 15));
+        let ytm = 0.03;
+        let mac = macaulay_duration(&bond, ytm, d(2025, 2, 15));
+        let modd = modified_duration(&bond, ytm, d(2025, 2, 15));
+        let expected = mac / (1.0 + ytm);
+        assert!((modd - expected).abs() < 1e-10,
+            "Euro mod_dur={}, expected mac/(1+y)={}", modd, expected);
+    }
+
+    #[test]
+    fn euro_duration_10y_bund() {
+        let bond = euro_bond(0.025, d(2035, 2, 15));
+        let dur = macaulay_duration(&bond, 0.025, d(2025, 2, 15));
+        assert!(dur > 8.0 && dur < 10.0, "10Y Bund duration={}", dur);
+    }
+
+    #[test]
+    fn euro_annual_longer_duration_than_semiannual() {
+        // Same coupon, maturity, and dated_date — annual pays less frequently so duration is higher
+        let dated = d(2025, 5, 15);
+        let maturity = d(2035, 5, 15);
+        let annual = BondSpec {
+            coupon_rate: 0.05, coupon_freq: 1, coupon_type: CouponType::Fixed,
+            face_value: 100.0, dated_date: dated, maturity_date: maturity,
+            day_count: DayCountConvention::ActualActualICMA,
+        };
+        let semi = BondSpec {
+            coupon_rate: 0.05, coupon_freq: 2, coupon_type: CouponType::Fixed,
+            face_value: 100.0, dated_date: dated, maturity_date: maturity,
+            day_count: DayCountConvention::ActualActualICMA,
+        };
+        let dur_annual = macaulay_duration(&annual, 0.05, dated);
+        let dur_semi = macaulay_duration(&semi, 0.05, dated);
+        assert!(dur_annual > dur_semi,
+            "Annual dur={} should > semi dur={}", dur_annual, dur_semi);
+    }
+
+    #[test]
+    fn euro_duration_convexity_approximation() {
+        let bond = euro_bond(0.025, d(2035, 2, 15));
+        let settle = d(2025, 2, 15);
+        let ytm = 0.03;
+        let dy = 0.01;
+
+        let p0 = super::super::pricing::dirty_price_from_yield(&bond, ytm, settle);
+        let p_actual = super::super::pricing::dirty_price_from_yield(&bond, ytm + dy, settle);
+
+        let mod_dur = modified_duration(&bond, ytm, settle);
+        let conv = super::super::convexity::convexity(&bond, ytm, settle);
+
+        let dp_approx = -mod_dur * p0 * dy + 0.5 * conv * p0 * dy * dy;
+        let p_approx = p0 + dp_approx;
+
+        let error_pct = ((p_approx - p_actual) / p_actual).abs();
+        assert!(error_pct < 0.001,
+            "Euro dur+conv approx error {:.4}%", error_pct * 100.0);
+    }
 }

--- a/valuation-calculator-rust/src/bond/ytm_solver.rs
+++ b/valuation-calculator-rust/src/bond/ytm_solver.rs
@@ -214,4 +214,68 @@ mod tests {
                 bond.coupon_rate, target_ytm, solved);
         }
     }
+
+    // ── Euro bond (annual coupon) tests ─────────────────────────────
+
+    fn euro_bond(coupon: f64, dated: Date, maturity: Date) -> BondSpec {
+        BondSpec {
+            coupon_rate: coupon, coupon_freq: 1, coupon_type: CouponType::Fixed,
+            face_value: 100.0, dated_date: dated, maturity_date: maturity,
+            day_count: DayCountConvention::ActualActualICMA,
+        }
+    }
+
+    #[test]
+    fn euro_par_bond_ytm_equals_coupon() {
+        let bond = euro_bond(0.025, d(2025, 2, 15), d(2035, 2, 15));
+        let ytm = solve_ytm(&bond, 100.0, d(2025, 2, 15)).unwrap();
+        assert!((ytm - 0.025).abs() < 1e-10, "Euro par YTM={}", ytm);
+    }
+
+    #[test]
+    fn euro_discount_bond() {
+        let bond = euro_bond(0.02, d(2025, 1, 4), d(2035, 1, 4));
+        let ytm = solve_ytm(&bond, 92.0, d(2025, 1, 4)).unwrap();
+        assert!(ytm > 0.02, "Euro discount YTM={}", ytm);
+    }
+
+    #[test]
+    fn euro_ytm_round_trip() {
+        let bond = euro_bond(0.03, d(2025, 2, 15), d(2035, 2, 15));
+        let target = 0.035;
+        let dp = super::super::pricing::dirty_price_from_yield(&bond, target, d(2025, 2, 15));
+        let solved = solve_ytm(&bond, dp, d(2025, 2, 15)).unwrap();
+        assert!((solved - target).abs() < 1e-10, "Euro round-trip: solved={}", solved);
+    }
+
+    #[test]
+    fn euro_ytm_round_trip_between_dates() {
+        let bond = euro_bond(0.025, d(2024, 7, 4), d(2034, 7, 4));
+        let settle = d(2025, 3, 15);
+        let target = 0.028;
+        let dp = super::super::pricing::dirty_price_from_yield(&bond, target, settle);
+        let ai = accrued_interest::accrued_interest(&bond, settle);
+        let cp = dp - ai;
+        let solved = solve_ytm(&bond, cp, settle).unwrap();
+        assert!((solved - target).abs() < 1e-10, "Euro between-dates: solved={}", solved);
+    }
+
+    #[test]
+    fn euro_round_trip_multiple() {
+        let bonds = vec![
+            euro_bond(0.01, d(2025, 1, 4), d(2027, 1, 4)),
+            euro_bond(0.025, d(2025, 2, 15), d(2035, 2, 15)),
+            euro_bond(0.04, d(2025, 7, 4), d(2055, 7, 4)),
+        ];
+        let yields = [0.02, 0.03, 0.035];
+
+        for (bond, &target) in bonds.iter().zip(yields.iter()) {
+            let settle = bond.dated_date;
+            let dp = super::super::pricing::dirty_price_from_yield(bond, target, settle);
+            let solved = solve_ytm(bond, dp, settle).unwrap();
+            assert!((solved - target).abs() < 1e-10,
+                "Euro round-trip failed: coupon={}, target={}, solved={}",
+                bond.coupon_rate, target, solved);
+        }
+    }
 }

--- a/valuation-calculator-rust/src/calculator.rs
+++ b/valuation-calculator-rust/src/calculator.rs
@@ -367,4 +367,144 @@ mod tests {
         assert!((pv - dp).abs() < 1e-8, "PV={} vs dirty={}", pv, dp);
         assert!((sum_cf_pv - dp).abs() < 1e-8, "sum_cf_pv={} vs dirty={}", sum_cf_pv, dp);
     }
+
+    // ── Euro bond (annual coupon) tests ─────────────────────────────
+
+    fn euro_request(coupon: f64, maturity: Date, price: f64, settle: Date, measures: Vec<Measure>) -> ValuationRequest {
+        ValuationRequest {
+            security: SecurityInput {
+                coupon_rate: coupon,
+                coupon_freq: 1,
+                coupon_type: CouponType::Fixed,
+                face_value: 100.0,
+                dated_date: d(2025, 2, 15),
+                maturity_date: maturity,
+            },
+            market_price: price,
+            quantity: 1_000_000.0,
+            cost_basis: Some(98.0),
+            settlement: settle,
+            measures,
+        }
+    }
+
+    #[test]
+    fn euro_full_valuation_par_bund() {
+        let req = euro_request(0.025, d(2035, 2, 15), 100.0, d(2025, 2, 15), vec![
+            Measure::YieldToMaturity,
+            Measure::MacaulayDuration,
+            Measure::ModifiedDuration,
+            Measure::Convexity,
+            Measure::Dv01,
+            Measure::AccruedInterest,
+            Measure::CleanPrice,
+            Measure::DirtyPrice,
+            Measure::MarketValue,
+            Measure::CurrentYield,
+            Measure::PresentValue,
+        ]);
+
+        let resp = valuate(&req);
+        assert!(resp.errors.is_empty(), "errors: {:?}", resp.errors);
+
+        let ytm = resp.get(Measure::YieldToMaturity).unwrap();
+        assert!((ytm - 0.025).abs() < 1e-10, "Bund par YTM={}", ytm);
+
+        let ai = resp.get(Measure::AccruedInterest).unwrap();
+        assert!(ai.abs() < 1e-15, "Bund AI on coupon date={}", ai);
+
+        let dur = resp.get(Measure::MacaulayDuration).unwrap();
+        assert!(dur > 8.0 && dur < 10.0, "Bund 10Y duration={}", dur);
+
+        let mv = resp.get(Measure::MarketValue).unwrap();
+        assert!((mv - 1_000_000.0).abs() < 1e-6, "Bund MV={}", mv);
+    }
+
+    #[test]
+    fn euro_cashflow_schedule_annual() {
+        let req = euro_request(0.03, d(2028, 2, 15), 100.0, d(2025, 2, 15), vec![
+            Measure::PresentValueCashflows,
+        ]);
+
+        let resp = valuate(&req);
+        assert!(resp.errors.is_empty());
+        assert_eq!(resp.cashflows.len(), 3, "3Y annual bond = 3 cashflows");
+
+        assert!((resp.cashflows[0].fv_amount - 3.0).abs() < 1e-10);
+        assert!((resp.cashflows[1].fv_amount - 3.0).abs() < 1e-10);
+        assert!((resp.cashflows[2].fv_amount - 103.0).abs() < 1e-10);
+
+        let sum_pv: f64 = resp.cashflows.iter().map(|cf| cf.pv_amount).sum();
+        assert!((sum_pv - 100.0).abs() < 1e-8, "sum_pv={}", sum_pv);
+    }
+
+    #[test]
+    fn euro_three_way_invariant() {
+        let req = euro_request(0.025, d(2035, 2, 15), 95.0, d(2025, 2, 15), vec![
+            Measure::PresentValue,
+            Measure::DirtyPrice,
+            Measure::PresentValueCashflows,
+        ]);
+
+        let resp = valuate(&req);
+        let pv = resp.get(Measure::PresentValue).unwrap();
+        let dp = resp.get(Measure::DirtyPrice).unwrap();
+        let sum_cf_pv: f64 = resp.cashflows.iter().map(|cf| cf.pv_amount).sum();
+
+        assert!((pv - dp).abs() < 1e-8);
+        assert!((sum_cf_pv - dp).abs() < 1e-8);
+    }
+
+    #[test]
+    fn euro_between_coupon_dates() {
+        let req = ValuationRequest {
+            security: SecurityInput {
+                coupon_rate: 0.025,
+                coupon_freq: 1,
+                coupon_type: CouponType::Fixed,
+                face_value: 100.0,
+                dated_date: d(2024, 7, 4),
+                maturity_date: d(2034, 7, 4),
+            },
+            market_price: 96.0,
+            quantity: 500_000.0,
+            cost_basis: None,
+            settlement: d(2025, 3, 15),
+            measures: vec![
+                Measure::YieldToMaturity,
+                Measure::AccruedInterest,
+                Measure::DirtyPrice,
+                Measure::MacaulayDuration,
+                Measure::Dv01,
+            ],
+        };
+
+        let resp = valuate(&req);
+        assert!(resp.errors.is_empty(), "errors: {:?}", resp.errors);
+
+        let ai = resp.get(Measure::AccruedInterest).unwrap();
+        assert!(ai > 1.0 && ai < 2.5, "Euro mid-period AI={}", ai);
+
+        let ytm = resp.get(Measure::YieldToMaturity).unwrap();
+        assert!(ytm > 0.025, "Euro discount YTM={} should > coupon", ytm);
+
+        let dv = resp.get(Measure::Dv01).unwrap();
+        assert!(dv > 0.0, "Euro DV01={}", dv);
+    }
+
+    #[test]
+    fn euro_profit_loss() {
+        let req = euro_request(0.025, d(2035, 2, 15), 102.0, d(2025, 2, 15), vec![
+            Measure::MarketValue,
+            Measure::ProfitLoss,
+        ]);
+
+        let resp = valuate(&req);
+        let mv = resp.get(Measure::MarketValue).unwrap();
+        let pl = resp.get(Measure::ProfitLoss).unwrap();
+
+        // price=102, qty=1M → MV=1,020,000. cost=98, → cost_MV=980,000. PL=40,000
+        assert!((mv - 1_020_000.0).abs() < 1e-6);
+        assert!((pl - 40_000.0).abs() < 1e-6, "Euro PL={}", pl);
+    }
 }


### PR DESCRIPTION
## Summary
- Adds support for annual-coupon bonds (Bunds, OATs) — `coupon_freq=1`
- No code changes needed — the math generalizes via the `coupon_freq` parameter
- 21 new tests proving correctness for Euro government bonds
- 88 tests total, all passing

## What's tested
- Annual coupon schedule generation
- Accrued interest with annual period length
- YTM solver round-trips for Euro bonds (on and between coupon dates)
- Modified duration = Macaulay / (1 + y) for annual bonds
- Annual duration > semiannual duration (same coupon/maturity)
- Duration+convexity price approximation < 0.1% error
- Full calculator pipeline for Bunds
- Three-way PV invariant for Euro bonds
- P&L calculation

## Test plan
- [x] `cargo test` — 88 tests, all passing