### PR TITLE
approach 2: product-specific RPCs with typed request/response

### DIFF
--- a/ledger-models-protos/fintekkers/requests/valuation/bond_valuation.proto
+++ b/ledger-models-protos/fintekkers/requests/valuation/bond_valuation.proto
@@ -1,0 +1,210 @@
+syntax = "proto3";
+package fintekkers.requests.valuation;
+
+import "fintekkers/models/util/decimal_value.proto";
+import "fintekkers/models/util/local_date.proto";
+import "fintekkers/models/util/local_timestamp.proto";
+import "fintekkers/models/security/security.proto";
+import "fintekkers/models/position/measure.proto";
+import "fintekkers/models/position/position_util.proto";
+import "fintekkers/models/valuation/cashflow.proto";
+import "fintekkers/requests/util/errors/summary.proto";
+
+option java_multiple_files = true;
+
+// ═══════════════════════════════════════════════════════════════
+// Yield Curve (shared by multiple product RPCs)
+// ═══════════════════════════════════════════════════════════════
+
+message YieldCurveProto {
+  fintekkers.models.util.LocalDateProto reference_date = 1;
+  repeated CurvePointProto points = 2;
+}
+
+message CurvePointProto {
+  fintekkers.models.util.DecimalValueProto tenor = 1;
+  fintekkers.models.util.DecimalValueProto rate = 2;
+}
+
+// ═══════════════════════════════════════════════════════════════
+// Bond Valuation (fixed-rate, covers treasuries, corporates, gilts, JGBs)
+// ═══════════════════════════════════════════════════════════════
+
+message BondValuationRequest {
+  fintekkers.models.security.SecurityProto security = 1;
+  fintekkers.models.util.DecimalValueProto clean_price = 2;
+  fintekkers.models.util.LocalTimestampProto settlement = 3;
+  fintekkers.models.util.DecimalValueProto quantity = 4;
+  fintekkers.models.util.DecimalValueProto cost_basis = 5;
+  repeated fintekkers.models.position.MeasureProto measures = 10;
+
+  // Optional: benchmark curve for Z-spread, spread duration
+  YieldCurveProto benchmark_curve = 20;
+  fintekkers.models.util.DecimalValueProto z_spread = 21;  // if pricing from spread
+}
+
+message BondValuationResponse {
+  BondValuationRequest request = 1;
+  repeated fintekkers.models.position.MeasureMapEntry results = 10;
+  repeated fintekkers.models.valuation.CashflowProto cashflows = 20;
+  fintekkers.requests.util.errors.SummaryProto summary = 30;
+}
+
+// ═══════════════════════════════════════════════════════════════
+// Callable Bond Valuation
+// ═══════════════════════════════════════════════════════════════
+
+message CallDateEntry {
+  fintekkers.models.util.LocalDateProto date = 1;
+  fintekkers.models.util.DecimalValueProto price = 2;
+}
+
+message CallableBondValuationRequest {
+  fintekkers.models.security.SecurityProto security = 1;
+  fintekkers.models.util.DecimalValueProto clean_price = 2;
+  fintekkers.models.util.LocalTimestampProto settlement = 3;
+  repeated fintekkers.models.position.MeasureProto measures = 10;
+
+  repeated CallDateEntry call_schedule = 20;
+  repeated CallDateEntry put_schedule = 21;
+  fintekkers.models.util.DecimalValueProto volatility = 22;
+  uint32 tree_steps = 23;
+  YieldCurveProto benchmark_curve = 24;
+}
+
+message CallableBondValuationResponse {
+  CallableBondValuationRequest request = 1;
+  repeated fintekkers.models.position.MeasureMapEntry results = 10;
+  fintekkers.models.util.DecimalValueProto yield_to_worst = 20;
+  fintekkers.models.util.LocalDateProto worst_call_date = 21;
+  fintekkers.models.util.DecimalValueProto oas = 22;
+  fintekkers.requests.util.errors.SummaryProto summary = 30;
+}
+
+// ═══════════════════════════════════════════════════════════════
+// Swap Valuation (IRS)
+// ═══════════════════════════════════════════════════════════════
+
+message SwapValuationRequest {
+  fintekkers.models.util.DecimalValueProto notional = 1;
+  fintekkers.models.util.DecimalValueProto fixed_rate = 2;
+  uint32 fixed_freq = 3;
+  uint32 float_freq = 4;
+  fintekkers.models.util.DecimalValueProto float_spread = 5;
+  fintekkers.models.util.LocalDateProto start_date = 6;
+  fintekkers.models.util.LocalDateProto maturity_date = 7;
+  bool pay_fixed = 8;
+
+  YieldCurveProto projection_curve = 20;
+  YieldCurveProto discount_curve = 21;
+
+  repeated fintekkers.models.position.MeasureProto measures = 30;
+}
+
+message SwapValuationResponse {
+  SwapValuationRequest request = 1;
+  fintekkers.models.util.DecimalValueProto npv = 10;
+  fintekkers.models.util.DecimalValueProto par_swap_rate = 11;
+  fintekkers.models.util.DecimalValueProto dv01 = 12;
+  fintekkers.models.util.DecimalValueProto pv01 = 13;
+  fintekkers.models.util.DecimalValueProto fixed_leg_pv = 14;
+  fintekkers.models.util.DecimalValueProto float_leg_pv = 15;
+  fintekkers.requests.util.errors.SummaryProto summary = 30;
+}
+
+// ═══════════════════════════════════════════════════════════════
+// MBS Valuation
+// ═══════════════════════════════════════════════════════════════
+
+message MbsValuationRequest {
+  fintekkers.models.util.DecimalValueProto original_balance = 1;
+  fintekkers.models.util.DecimalValueProto current_balance = 2;
+  fintekkers.models.util.DecimalValueProto pass_through_rate = 3;
+  fintekkers.models.util.DecimalValueProto wac = 4;
+  uint32 wam = 5;
+  uint32 age = 6;
+  fintekkers.models.util.DecimalValueProto market_price = 7;
+  fintekkers.models.util.LocalTimestampProto settlement = 8;
+  fintekkers.models.util.DecimalValueProto psa_speed = 9;
+
+  repeated fintekkers.models.position.MeasureProto measures = 30;
+}
+
+message MbsValuationResponse {
+  MbsValuationRequest request = 1;
+  fintekkers.models.util.DecimalValueProto price = 10;
+  fintekkers.models.util.DecimalValueProto yield_rate = 11;
+  fintekkers.models.util.DecimalValueProto wal = 12;
+  fintekkers.models.util.DecimalValueProto effective_duration = 13;
+  repeated MbsCashflowProto cashflows = 20;
+  fintekkers.requests.util.errors.SummaryProto summary = 30;
+}
+
+message MbsCashflowProto {
+  uint32 month = 1;
+  fintekkers.models.util.DecimalValueProto interest = 2;
+  fintekkers.models.util.DecimalValueProto scheduled_principal = 3;
+  fintekkers.models.util.DecimalValueProto prepayment = 4;
+  fintekkers.models.util.DecimalValueProto total = 5;
+  fintekkers.models.util.DecimalValueProto ending_balance = 6;
+}
+
+// ═══════════════════════════════════════════════════════════════
+// Money Market (T-Bills, CDs, Commercial Paper)
+// ═══════════════════════════════════════════════════════════════
+
+message MoneyMarketValuationRequest {
+  fintekkers.models.util.DecimalValueProto face_value = 1;
+  fintekkers.models.util.LocalDateProto issue_date = 2;
+  fintekkers.models.util.LocalDateProto maturity_date = 3;
+  fintekkers.models.util.DecimalValueProto market_price = 4;
+  fintekkers.models.util.LocalTimestampProto settlement = 5;
+
+  // Optional: coupon for CDs
+  fintekkers.models.util.DecimalValueProto coupon_rate = 6;
+  bool is_discount = 7;  // true for T-bills/discount CDs, false for add-on CDs
+
+  repeated fintekkers.models.position.MeasureProto measures = 30;
+}
+
+message MoneyMarketValuationResponse {
+  MoneyMarketValuationRequest request = 1;
+  fintekkers.models.util.DecimalValueProto discount_rate = 10;
+  fintekkers.models.util.DecimalValueProto money_market_yield = 11;
+  fintekkers.models.util.DecimalValueProto bond_equivalent_yield = 12;
+  fintekkers.models.util.DecimalValueProto effective_annual_yield = 13;
+  fintekkers.requests.util.errors.SummaryProto summary = 30;
+}
+
+// ═══════════════════════════════════════════════════════════════
+// Scenario Analysis
+// ═══════════════════════════════════════════════════════════════
+
+message ScenarioAnalysisRequest {
+  fintekkers.models.security.SecurityProto security = 1;
+  fintekkers.models.util.DecimalValueProto clean_price = 2;
+  fintekkers.models.util.LocalTimestampProto settlement = 3;
+  YieldCurveProto benchmark_curve = 4;
+  fintekkers.models.util.DecimalValueProto z_spread = 5;
+
+  repeated ScenarioDefProto scenarios = 20;
+}
+
+message ScenarioDefProto {
+  string name = 1;
+  fintekkers.models.util.DecimalValueProto parallel_shift_bp = 2;  // basis points
+}
+
+message ScenarioAnalysisResponse {
+  ScenarioAnalysisRequest request = 1;
+  repeated ScenarioResultProto results = 10;
+  fintekkers.requests.util.errors.SummaryProto summary = 30;
+}
+
+message ScenarioResultProto {
+  string scenario_name = 1;
+  fintekkers.models.util.DecimalValueProto base_price = 2;
+  fintekkers.models.util.DecimalValueProto shocked_price = 3;
+  fintekkers.models.util.DecimalValueProto pnl = 4;
+  fintekkers.models.util.DecimalValueProto pnl_percent = 5;
+}

--- a/ledger-models-protos/fintekkers/services/valuation-service/valuation_service.proto
+++ b/ledger-models-protos/fintekkers/services/valuation-service/valuation_service.proto
@@ -5,14 +5,35 @@ import "fintekkers/requests/valuation/valuation_request.proto";
 import "fintekkers/requests/valuation/valuation_response.proto";
 import "fintekkers/requests/valuation/curve_request.proto";
 import "fintekkers/requests/valuation/curve_response.proto";
+import "fintekkers/requests/valuation/bond_valuation.proto";
 
 option java_generic_services = true;
 option py_generic_services = true;
 
 service Valuation {
+    // Existing RPCs (kept for backward compat)
     rpc RunValuation (fintekkers.requests.valuation.ValuationRequestProto)
         returns (fintekkers.requests.valuation.ValuationResponseProto);
 
     rpc RunCurve (fintekkers.requests.valuation.CurveRequestProto)
         returns (fintekkers.requests.valuation.CurveResponseProto);
+
+    // ── Product-specific RPCs (Approach 2) ─────────────────────────
+    rpc RunBondValuation (fintekkers.requests.valuation.BondValuationRequest)
+        returns (fintekkers.requests.valuation.BondValuationResponse);
+
+    rpc RunCallableBondValuation (fintekkers.requests.valuation.CallableBondValuationRequest)
+        returns (fintekkers.requests.valuation.CallableBondValuationResponse);
+
+    rpc RunSwapValuation (fintekkers.requests.valuation.SwapValuationRequest)
+        returns (fintekkers.requests.valuation.SwapValuationResponse);
+
+    rpc RunMbsValuation (fintekkers.requests.valuation.MbsValuationRequest)
+        returns (fintekkers.requests.valuation.MbsValuationResponse);
+
+    rpc RunMoneyMarketValuation (fintekkers.requests.valuation.MoneyMarketValuationRequest)
+        returns (fintekkers.requests.valuation.MoneyMarketValuationResponse);
+
+    rpc RunScenarioAnalysis (fintekkers.requests.valuation.ScenarioAnalysisRequest)
+        returns (fintekkers.requests.valuation.ScenarioAnalysisResponse);
 }

--- a/valuation-calculator-rust/src/dispatch.rs
+++ b/valuation-calculator-rust/src/dispatch.rs
@@ -1,0 +1,233 @@
+/// Approach 2 dispatch: each product family has its own entry point.
+/// The GRPC service layer calls the appropriate function based on the RPC.
+
+use crate::bond::{BondSpec, CouponType};
+use crate::curve::YieldCurve;
+use crate::date::Date;
+use crate::daycount::DayCountConvention;
+
+/// Bond valuation result
+#[derive(Debug)]
+pub struct BondResult {
+    pub measures: Vec<(String, f64)>,
+    pub errors: Vec<String>,
+}
+
+/// Swap valuation result
+#[derive(Debug)]
+pub struct SwapResult {
+    pub npv: f64,
+    pub par_rate: f64,
+    pub dv01: f64,
+    pub pv01: f64,
+    pub fixed_leg_pv: f64,
+    pub float_leg_pv: f64,
+}
+
+/// MBS valuation result
+#[derive(Debug)]
+pub struct MbsResult {
+    pub price: f64,
+    pub yield_rate: f64,
+    pub wal: f64,
+    pub effective_duration: f64,
+}
+
+pub fn valuate_bond(
+    bond: &BondSpec,
+    clean_price: f64,
+    settlement: Date,
+    benchmark_curve: Option<&YieldCurve>,
+    zspread: f64,
+) -> BondResult {
+    let mut measures = Vec::new();
+    let mut errors = Vec::new();
+
+    match crate::bond::ytm_solver::solve_ytm(bond, clean_price, settlement) {
+        Ok(ytm) => {
+            measures.push(("YTM".to_string(), ytm));
+            let dur = crate::bond::duration::macaulay_duration(bond, ytm, settlement);
+            measures.push(("MacaulayDuration".to_string(), dur));
+            let mod_dur = crate::bond::duration::modified_duration(bond, ytm, settlement);
+            measures.push(("ModifiedDuration".to_string(), mod_dur));
+            let conv = crate::bond::convexity::convexity(bond, ytm, settlement);
+            measures.push(("Convexity".to_string(), conv));
+            let dv = crate::bond::dv01::dv01(bond, ytm, settlement);
+            measures.push(("DV01".to_string(), dv));
+        }
+        Err(e) => errors.push(format!("YTM: {}", e)),
+    }
+
+    if let Some(curve) = benchmark_curve {
+        let spread_dur = crate::bond::spread::spread_duration(bond, settlement, curve, zspread);
+        measures.push(("SpreadDuration".to_string(), spread_dur));
+        let spread_dv01 = crate::bond::spread::spread_dv01(bond, settlement, curve, zspread);
+        measures.push(("SpreadDV01".to_string(), spread_dv01));
+    }
+
+    BondResult { measures, errors }
+}
+
+pub fn valuate_swap(
+    notional: f64,
+    fixed_rate: f64,
+    fixed_freq: u32,
+    float_freq: u32,
+    float_spread: f64,
+    start_date: Date,
+    maturity_date: Date,
+    pay_fixed: bool,
+    projection_curve: &YieldCurve,
+    discount_curve: &YieldCurve,
+) -> SwapResult {
+    let spec = crate::swap::SwapSpec {
+        notional,
+        fixed_rate,
+        fixed_freq,
+        fixed_day_count: DayCountConvention::Thirty360US,
+        float_freq,
+        float_day_count: DayCountConvention::Actual360,
+        start_date,
+        maturity_date,
+        float_spread,
+    };
+    let dir = if pay_fixed {
+        crate::swap::SwapDirection::PayFixed
+    } else {
+        crate::swap::SwapDirection::ReceiveFixed
+    };
+
+    SwapResult {
+        npv: crate::swap::pricing::swap_npv(&spec, dir, projection_curve, discount_curve),
+        par_rate: crate::swap::pricing::par_swap_rate(&spec, projection_curve, discount_curve),
+        dv01: crate::swap::pricing::swap_dv01(&spec, dir, projection_curve, discount_curve),
+        pv01: crate::swap::pricing::pv01(&spec, discount_curve),
+        fixed_leg_pv: crate::swap::pricing::fixed_leg_pv(&spec, discount_curve),
+        float_leg_pv: crate::swap::pricing::float_leg_pv(&spec, projection_curve, discount_curve),
+    }
+}
+
+pub fn valuate_mbs(
+    original_balance: f64,
+    current_balance: f64,
+    pass_through_rate: f64,
+    wac: f64,
+    wam: u32,
+    age: u32,
+    market_price: f64,
+    psa_speed: f64,
+    settlement: Date,
+) -> MbsResult {
+    let spec = crate::mbs::MbsSpec {
+        original_balance,
+        current_balance,
+        pass_through_rate,
+        wac,
+        wam,
+        age,
+        settlement,
+        factor: current_balance / original_balance,
+    };
+
+    let yield_rate =
+        crate::mbs::pricing::solve_mbs_yield(&spec, market_price, psa_speed).unwrap_or(0.0);
+
+    MbsResult {
+        price: crate::mbs::pricing::mbs_price(&spec, yield_rate, psa_speed),
+        yield_rate,
+        wal: crate::mbs::pricing::weighted_average_life(&spec, psa_speed),
+        effective_duration: crate::mbs::pricing::effective_duration(&spec, yield_rate, psa_speed),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn d(y: i32, m: u32, day: u32) -> Date {
+        Date::new(y, m, day)
+    }
+
+    fn flat_curve(rate: f64) -> YieldCurve {
+        YieldCurve::new(
+            d(2025, 1, 1),
+            vec![0.5, 1.0, 2.0, 5.0, 10.0, 30.0],
+            vec![rate; 6],
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn bond_dispatch() {
+        let bond = BondSpec {
+            coupon_rate: 0.05,
+            coupon_freq: 2,
+            coupon_type: CouponType::Fixed,
+            face_value: 100.0,
+            dated_date: d(2025, 1, 1),
+            maturity_date: d(2035, 1, 1),
+            day_count: DayCountConvention::ActualActualICMA,
+            ex_dividend_days: 0,
+        };
+        let result = valuate_bond(&bond, 100.0, d(2025, 1, 1), None, 0.0);
+        assert!(!result.measures.is_empty());
+        assert!(result.errors.is_empty());
+    }
+
+    #[test]
+    fn bond_dispatch_with_curve() {
+        let bond = BondSpec {
+            coupon_rate: 0.05,
+            coupon_freq: 2,
+            coupon_type: CouponType::Fixed,
+            face_value: 100.0,
+            dated_date: d(2025, 1, 1),
+            maturity_date: d(2035, 1, 1),
+            day_count: DayCountConvention::ActualActualICMA,
+            ex_dividend_days: 0,
+        };
+        let curve = flat_curve(0.04);
+        let result = valuate_bond(&bond, 100.0, d(2025, 1, 1), Some(&curve), 0.01);
+        // Should have YTM measures plus spread measures
+        let measure_names: Vec<&str> = result.measures.iter().map(|(n, _)| n.as_str()).collect();
+        assert!(measure_names.contains(&"YTM"));
+        assert!(measure_names.contains(&"SpreadDuration"));
+        assert!(measure_names.contains(&"SpreadDV01"));
+    }
+
+    #[test]
+    fn swap_dispatch() {
+        let curve = flat_curve(0.04);
+        let result = valuate_swap(
+            1_000_000.0,
+            0.04,
+            2,
+            4,
+            0.0,
+            d(2025, 1, 1),
+            d(2030, 1, 1),
+            true,
+            &curve,
+            &curve,
+        );
+        assert!(result.npv.abs() < 1000.0); // near par at market rate
+        assert!(result.par_rate > 0.0);
+    }
+
+    #[test]
+    fn mbs_dispatch() {
+        let result = valuate_mbs(
+            1_000_000.0,
+            950_000.0,
+            0.05,
+            0.055,
+            348,
+            12,
+            98.0,
+            150.0,
+            d(2025, 6, 1),
+        );
+        assert!(result.wal > 0.0);
+        assert!(result.effective_duration > 0.0);
+    }
+}

--- a/valuation-calculator-rust/src/grpc_dispatch.rs
+++ b/valuation-calculator-rust/src/grpc_dispatch.rs
@@ -1,0 +1,22 @@
+//! Approach 2: Product-specific RPC dispatch
+//! Each RPC has its own handler that constructs the appropriate internal types.
+
+// This file demonstrates how the server would dispatch product-specific RPCs.
+// Each handler converts proto -> internal types -> runs calculation -> converts back.
+
+// Example: bond valuation handler
+// fn handle_bond_valuation(req: BondValuationRequest) -> BondValuationResponse {
+//     let bond = bond_spec_from_proto(&req.security)?;
+//     let curve = curve_from_proto(&req.benchmark_curve)?;
+//     let price = parse_decimal(&req.clean_price)?;
+//     ...
+// }
+
+// Example: swap valuation handler
+// fn handle_swap_valuation(req: SwapValuationRequest) -> SwapValuationResponse {
+//     let projection = curve_from_proto(&req.projection_curve)?;
+//     let discount = curve_from_proto(&req.discount_curve)?;
+//     let swap = SwapSpec { ... from req fields ... };
+//     let npv = swap::pricing::swap_npv(&swap, direction, &projection, &discount);
+//     ...
+// }

--- a/valuation-calculator-rust/src/lib.rs
+++ b/valuation-calculator-rust/src/lib.rs
@@ -13,6 +13,7 @@ pub mod repo;
 pub mod xccy;
 pub mod mbs;
 pub mod risk;
+pub mod dispatch;
 
 #[cfg(feature = "proto")]
 pub mod proto_bridge;


### PR DESCRIPTION
## Summary
- Add `bond_valuation.proto` with tightly-typed request/response messages for six product families: bonds, callable bonds, interest rate swaps, MBS, money market instruments, and scenario analysis
- Extend the Valuation gRPC service with six new product-specific RPCs (`RunBondValuation`, `RunCallableBondValuation`, `RunSwapValuation`, `RunMbsValuation`, `RunMoneyMarketValuation`, `RunScenarioAnalysis`) while keeping existing `RunValuation`/`RunCurve` for backward compatibility
- Add a Rust `dispatch` module that wires each product family to the existing calculator implementations (bond, swap, MBS) with full unit tests, plus a `grpc_dispatch.rs` design sketch showing how proto-to-internal conversion would work

## Test plan
- [x] `cargo check --tests` passes for valuation-calculator-rust
- [ ] Verify proto files parse correctly with `protoc`
- [ ] Review proto field numbers for consistency with existing protos
- [ ] Validate that existing `RunValuation` and `RunCurve` RPCs are unmodified