### PR TITLE
approach 3: single RPC with oneof product_input dispatch

### DIFF
--- a/ledger-models-protos/fintekkers/requests/valuation/product_inputs.proto
+++ b/ledger-models-protos/fintekkers/requests/valuation/product_inputs.proto
@@ -1,0 +1,208 @@
+syntax = "proto3";
+package fintekkers.requests.valuation;
+
+import "fintekkers/models/util/decimal_value.proto";
+import "fintekkers/models/util/local_date.proto";
+import "fintekkers/models/util/local_timestamp.proto";
+import "fintekkers/models/security/security.proto";
+import "fintekkers/models/position/measure.proto";
+
+option java_multiple_files = true;
+option java_outer_classname = "ProductInputProtos";
+
+// ═══════════════════════════════════════════════════════════════
+// Shared types
+// ═══════════════════════════════════════════════════════════════
+
+message YieldCurveInput {
+  fintekkers.models.util.LocalDateProto reference_date = 1;
+  repeated CurvePoint points = 2;
+}
+
+message CurvePoint {
+  fintekkers.models.util.DecimalValueProto tenor = 1;
+  fintekkers.models.util.DecimalValueProto rate = 2;
+}
+
+// ═══════════════════════════════════════════════════════════════
+// The oneof: exactly one product input per valuation request
+// ═══════════════════════════════════════════════════════════════
+
+message ProductInput {
+  oneof input {
+    BondInput bond = 1;
+    CallableBondInput callable_bond = 2;
+    SwapInput swap = 3;
+    MbsInput mbs = 4;
+    MoneyMarketInput money_market = 5;
+    RepoInput repo = 6;
+    TipsInput tips = 7;
+    FrnInput frn = 8;
+    LoanInput loan = 9;
+    FuturesInput futures = 10;
+    MuniInput muni = 11;
+    XccySwapInput xccy_swap = 12;
+    AmortizingBondInput amortizing_bond = 13;
+    ScenarioInput scenario = 14;
+  }
+}
+
+// ═══════════════════════════════════════════════════════════════
+// Product-specific input messages
+// ═══════════════════════════════════════════════════════════════
+
+message BondInput {
+  fintekkers.models.security.SecurityProto security = 1;
+  fintekkers.models.util.DecimalValueProto clean_price = 2;
+  // Optional: for spread-based pricing
+  YieldCurveInput benchmark_curve = 10;
+  fintekkers.models.util.DecimalValueProto z_spread = 11;
+}
+
+message CallableBondInput {
+  fintekkers.models.security.SecurityProto security = 1;
+  fintekkers.models.util.DecimalValueProto clean_price = 2;
+  repeated CallEntry call_schedule = 10;
+  repeated CallEntry put_schedule = 11;
+  fintekkers.models.util.DecimalValueProto volatility = 12;
+  uint32 tree_steps = 13;
+  YieldCurveInput benchmark_curve = 14;
+}
+
+message CallEntry {
+  fintekkers.models.util.LocalDateProto date = 1;
+  fintekkers.models.util.DecimalValueProto price = 2;
+}
+
+message SwapInput {
+  fintekkers.models.util.DecimalValueProto notional = 1;
+  fintekkers.models.util.DecimalValueProto fixed_rate = 2;
+  uint32 fixed_freq = 3;
+  uint32 float_freq = 4;
+  fintekkers.models.util.DecimalValueProto float_spread = 5;
+  fintekkers.models.util.LocalDateProto start_date = 6;
+  fintekkers.models.util.LocalDateProto maturity_date = 7;
+  bool pay_fixed = 8;
+  YieldCurveInput projection_curve = 20;
+  YieldCurveInput discount_curve = 21;
+}
+
+message MbsInput {
+  fintekkers.models.util.DecimalValueProto original_balance = 1;
+  fintekkers.models.util.DecimalValueProto current_balance = 2;
+  fintekkers.models.util.DecimalValueProto pass_through_rate = 3;
+  fintekkers.models.util.DecimalValueProto wac = 4;
+  uint32 wam = 5;
+  uint32 age = 6;
+  fintekkers.models.util.DecimalValueProto market_price = 7;
+  fintekkers.models.util.DecimalValueProto psa_speed = 8;
+}
+
+message MoneyMarketInput {
+  fintekkers.models.util.DecimalValueProto face_value = 1;
+  fintekkers.models.util.LocalDateProto issue_date = 2;
+  fintekkers.models.util.LocalDateProto maturity_date = 3;
+  fintekkers.models.util.DecimalValueProto market_price = 4;
+  fintekkers.models.util.DecimalValueProto coupon_rate = 5;
+  bool is_discount = 6;
+}
+
+message RepoInput {
+  fintekkers.models.util.DecimalValueProto collateral_dirty_price = 1;
+  fintekkers.models.util.DecimalValueProto collateral_face = 2;
+  fintekkers.models.util.DecimalValueProto haircut = 3;
+  fintekkers.models.util.DecimalValueProto repo_rate = 4;
+  fintekkers.models.util.LocalDateProto start_date = 5;
+  fintekkers.models.util.LocalDateProto end_date = 6;
+}
+
+message TipsInput {
+  fintekkers.models.security.SecurityProto security = 1;
+  fintekkers.models.util.DecimalValueProto clean_price = 2;
+  fintekkers.models.util.DecimalValueProto base_cpi = 3;
+  fintekkers.models.util.DecimalValueProto current_cpi = 4;
+  fintekkers.models.util.DecimalValueProto nominal_yield = 5;  // for breakeven calc
+}
+
+message FrnInput {
+  fintekkers.models.security.SecurityProto security = 1;
+  fintekkers.models.util.DecimalValueProto clean_price = 2;
+  YieldCurveInput projection_curve = 10;
+  YieldCurveInput discount_curve = 11;
+}
+
+message LoanInput {
+  fintekkers.models.util.DecimalValueProto face_value = 1;
+  fintekkers.models.util.DecimalValueProto spread = 2;
+  uint32 payment_freq = 3;
+  fintekkers.models.util.LocalDateProto dated_date = 4;
+  fintekkers.models.util.LocalDateProto maturity_date = 5;
+  fintekkers.models.util.DecimalValueProto market_price = 6;
+  YieldCurveInput projection_curve = 10;
+  YieldCurveInput discount_curve = 11;
+  bool is_amortizing = 20;
+  repeated AmortEntry amortization = 21;
+}
+
+message AmortEntry {
+  fintekkers.models.util.LocalDateProto date = 1;
+  fintekkers.models.util.DecimalValueProto principal_fraction = 2;
+}
+
+message FuturesInput {
+  fintekkers.models.util.DecimalValueProto futures_price = 1;
+  fintekkers.models.util.DecimalValueProto contract_size = 2;
+  fintekkers.models.util.LocalDateProto expiry_date = 3;
+  fintekkers.models.util.LocalDateProto delivery_date = 4;
+  fintekkers.models.security.SecurityProto ctd_bond = 5;
+  fintekkers.models.util.DecimalValueProto ctd_clean_price = 6;
+  fintekkers.models.util.DecimalValueProto volatility = 7;
+}
+
+message MuniInput {
+  fintekkers.models.security.SecurityProto security = 1;
+  fintekkers.models.util.DecimalValueProto clean_price = 2;
+  fintekkers.models.util.DecimalValueProto federal_rate = 10;
+  fintekkers.models.util.DecimalValueProto state_rate = 11;
+  fintekkers.models.util.DecimalValueProto local_rate = 12;
+  fintekkers.models.util.DecimalValueProto agi_surcharge = 13;
+  bool is_in_state = 14;
+  // Call schedule (most munis are callable)
+  repeated CallEntry call_schedule = 20;
+}
+
+message XccySwapInput {
+  fintekkers.models.util.DecimalValueProto domestic_notional = 1;
+  fintekkers.models.util.DecimalValueProto foreign_notional = 2;
+  fintekkers.models.util.DecimalValueProto domestic_fixed_rate = 3;
+  fintekkers.models.util.DecimalValueProto foreign_fixed_rate = 4;
+  uint32 domestic_freq = 5;
+  uint32 foreign_freq = 6;
+  fintekkers.models.util.LocalDateProto start_date = 7;
+  fintekkers.models.util.LocalDateProto maturity_date = 8;
+  fintekkers.models.util.DecimalValueProto spot_fx = 9;
+  fintekkers.models.util.DecimalValueProto basis_spread = 10;
+  bool exchange_notional = 11;
+  YieldCurveInput domestic_curve = 20;
+  YieldCurveInput foreign_curve = 21;
+}
+
+message AmortizingBondInput {
+  fintekkers.models.security.SecurityProto security = 1;
+  fintekkers.models.util.DecimalValueProto market_price = 2;
+  string schedule_type = 10;  // "level_principal", "level_payment", "custom", "pro_rata"
+  fintekkers.models.util.DecimalValueProto pro_rata_fraction = 11;
+  repeated AmortEntry custom_schedule = 12;
+}
+
+message ScenarioInput {
+  BondInput bond = 1;
+  YieldCurveInput benchmark_curve = 2;
+  fintekkers.models.util.DecimalValueProto z_spread = 3;
+  repeated ScenarioDef scenarios = 10;
+}
+
+message ScenarioDef {
+  string name = 1;
+  fintekkers.models.util.DecimalValueProto parallel_shift_bp = 2;
+}

--- a/ledger-models-protos/fintekkers/requests/valuation/valuation_request.proto
+++ b/ledger-models-protos/fintekkers/requests/valuation/valuation_request.proto
@@ -9,6 +9,7 @@ import "fintekkers/models/util/local_timestamp.proto";
 
 import "fintekkers/requests/util/operation.proto";
 import "fintekkers/models/position/measure.proto";
+import "fintekkers/requests/valuation/product_inputs.proto";
 
 option java_multiple_files = true;
 
@@ -47,6 +48,11 @@ message ValuationRequestProto {
   //The current reference rate observation for floating rate note (FRN) valuation.
   //Modeled as a PriceProto on an INDEX_SECURITY representing the benchmark (e.g. SOFR).
   fintekkers.models.price.PriceProto reference_rate_input = 25;
+
+  // Product-specific input (determines calculation path)
+  // When set, overrides the security_input/price_input/cpi_price_input fields.
+  // Dispatch is based on which oneof variant is populated.
+  ProductInput product_input = 70;
 }
 
 

--- a/valuation-calculator-rust/src/dispatch.rs
+++ b/valuation-calculator-rust/src/dispatch.rs
@@ -1,0 +1,311 @@
+/// Approach 3: single entry point with oneof dispatch.
+/// The GRPC handler calls `dispatch_valuation` which routes to the appropriate module.
+
+use crate::date::Date;
+use crate::curve::YieldCurve;
+
+/// Unified valuation result
+#[derive(Debug, Clone)]
+pub struct ValuationResult {
+    pub measures: Vec<(String, f64)>,
+    pub cashflows: Vec<CashflowEntry>,
+    pub errors: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct CashflowEntry {
+    pub period: u32,
+    pub amount: f64,
+    pub pv: f64,
+}
+
+/// Product input enum matching the proto oneof
+#[derive(Debug, Clone)]
+pub enum ProductInput {
+    Bond(BondInput),
+    Swap(SwapInput),
+    Mbs(MbsInput),
+    MoneyMarket(MoneyMarketInput),
+    Repo(RepoInput),
+}
+
+#[derive(Debug, Clone)]
+pub struct BondInput {
+    pub coupon_rate: f64,
+    pub coupon_freq: u32,
+    pub face_value: f64,
+    pub dated_date: Date,
+    pub maturity_date: Date,
+    pub clean_price: f64,
+    pub settlement: Date,
+    pub benchmark_curve: Option<YieldCurve>,
+    pub z_spread: f64,
+}
+
+#[derive(Debug, Clone)]
+pub struct SwapInput {
+    pub notional: f64,
+    pub fixed_rate: f64,
+    pub fixed_freq: u32,
+    pub float_freq: u32,
+    pub float_spread: f64,
+    pub start_date: Date,
+    pub maturity_date: Date,
+    pub pay_fixed: bool,
+    pub projection_curve: YieldCurve,
+    pub discount_curve: YieldCurve,
+}
+
+#[derive(Debug, Clone)]
+pub struct MbsInput {
+    pub original_balance: f64,
+    pub current_balance: f64,
+    pub pass_through_rate: f64,
+    pub wac: f64,
+    pub wam: u32,
+    pub age: u32,
+    pub market_price: f64,
+    pub psa_speed: f64,
+    pub settlement: Date,
+}
+
+#[derive(Debug, Clone)]
+pub struct MoneyMarketInput {
+    pub face_value: f64,
+    pub issue_date: Date,
+    pub maturity_date: Date,
+    pub market_price: f64,
+    pub settlement: Date,
+    pub is_discount: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct RepoInput {
+    pub collateral_dirty_price: f64,
+    pub collateral_face: f64,
+    pub haircut: f64,
+    pub repo_rate: f64,
+    pub start_date: Date,
+    pub end_date: Date,
+}
+
+/// Main dispatch function -- routes to the appropriate product handler
+pub fn dispatch_valuation(input: &ProductInput, _settlement: Date) -> ValuationResult {
+    match input {
+        ProductInput::Bond(b) => valuate_bond(b),
+        ProductInput::Swap(s) => valuate_swap(s),
+        ProductInput::Mbs(m) => valuate_mbs(m),
+        ProductInput::MoneyMarket(mm) => valuate_money_market(mm),
+        ProductInput::Repo(r) => valuate_repo(r),
+    }
+}
+
+fn valuate_bond(input: &BondInput) -> ValuationResult {
+    use crate::bond::*;
+    use crate::daycount::DayCountConvention;
+
+    let bond = BondSpec {
+        coupon_rate: input.coupon_rate,
+        coupon_freq: input.coupon_freq,
+        coupon_type: CouponType::Fixed,
+        face_value: input.face_value,
+        dated_date: input.dated_date,
+        maturity_date: input.maturity_date,
+        day_count: DayCountConvention::ActualActualICMA,
+        ex_dividend_days: 0,
+    };
+
+    let mut measures = Vec::new();
+    let mut errors = Vec::new();
+
+    let ai = accrued_interest::accrued_interest(&bond, input.settlement);
+    measures.push(("AccruedInterest".into(), ai));
+    measures.push(("CleanPrice".into(), input.clean_price));
+    measures.push(("DirtyPrice".into(), input.clean_price + ai));
+
+    match ytm_solver::solve_ytm(&bond, input.clean_price, input.settlement) {
+        Ok(ytm) => {
+            measures.push(("YieldToMaturity".into(), ytm));
+            measures.push(("MacaulayDuration".into(), duration::macaulay_duration(&bond, ytm, input.settlement)));
+            measures.push(("ModifiedDuration".into(), duration::modified_duration(&bond, ytm, input.settlement)));
+            measures.push(("Convexity".into(), convexity::convexity(&bond, ytm, input.settlement)));
+            measures.push(("DV01".into(), dv01::dv01(&bond, ytm, input.settlement)));
+        }
+        Err(e) => errors.push(format!("{}", e)),
+    }
+
+    if let Some(ref curve) = input.benchmark_curve {
+        measures.push(("SpreadDuration".into(), spread::spread_duration(&bond, input.settlement, curve, input.z_spread)));
+        measures.push(("SpreadDV01".into(), spread::spread_dv01(&bond, input.settlement, curve, input.z_spread)));
+    }
+
+    ValuationResult { measures, cashflows: vec![], errors }
+}
+
+fn valuate_swap(input: &SwapInput) -> ValuationResult {
+    use crate::swap::*;
+    use crate::daycount::DayCountConvention;
+
+    let spec = SwapSpec {
+        notional: input.notional,
+        fixed_rate: input.fixed_rate,
+        fixed_freq: input.fixed_freq,
+        fixed_day_count: DayCountConvention::Thirty360US,
+        float_freq: input.float_freq,
+        float_day_count: DayCountConvention::Actual360,
+        start_date: input.start_date,
+        maturity_date: input.maturity_date,
+        float_spread: input.float_spread,
+    };
+    let dir = if input.pay_fixed { SwapDirection::PayFixed } else { SwapDirection::ReceiveFixed };
+
+    let mut measures = Vec::new();
+    measures.push(("NPV".into(), pricing::swap_npv(&spec, dir, &input.projection_curve, &input.discount_curve)));
+    measures.push(("ParSwapRate".into(), pricing::par_swap_rate(&spec, &input.projection_curve, &input.discount_curve)));
+    measures.push(("DV01".into(), pricing::swap_dv01(&spec, dir, &input.projection_curve, &input.discount_curve)));
+    measures.push(("PV01".into(), pricing::pv01(&spec, &input.discount_curve)));
+    measures.push(("FixedLegPV".into(), pricing::fixed_leg_pv(&spec, &input.discount_curve)));
+    measures.push(("FloatLegPV".into(), pricing::float_leg_pv(&spec, &input.projection_curve, &input.discount_curve)));
+
+    ValuationResult { measures, cashflows: vec![], errors: vec![] }
+}
+
+fn valuate_mbs(input: &MbsInput) -> ValuationResult {
+    let spec = crate::mbs::MbsSpec {
+        original_balance: input.original_balance,
+        current_balance: input.current_balance,
+        pass_through_rate: input.pass_through_rate,
+        wac: input.wac,
+        wam: input.wam,
+        age: input.age,
+        settlement: input.settlement,
+        factor: input.current_balance / input.original_balance,
+    };
+
+    let mut measures = Vec::new();
+    let mut errors = Vec::new();
+
+    match crate::mbs::pricing::solve_mbs_yield(&spec, input.market_price, input.psa_speed) {
+        Ok(y) => {
+            measures.push(("Yield".into(), y));
+            measures.push(("Price".into(), crate::mbs::pricing::mbs_price(&spec, y, input.psa_speed)));
+            measures.push(("EffectiveDuration".into(), crate::mbs::pricing::effective_duration(&spec, y, input.psa_speed)));
+        }
+        Err(e) => errors.push(format!("{}", e)),
+    }
+    measures.push(("WAL".into(), crate::mbs::pricing::weighted_average_life(&spec, input.psa_speed)));
+    measures.push(("WALSensitivity".into(), crate::mbs::pricing::wal_sensitivity(&spec, input.psa_speed)));
+
+    ValuationResult { measures, cashflows: vec![], errors }
+}
+
+fn valuate_money_market(input: &MoneyMarketInput) -> ValuationResult {
+    let days = input.maturity_date.days_since(&input.settlement) as u32;
+    let face = input.face_value;
+    let price = input.market_price;
+
+    let mut measures = Vec::new();
+    measures.push(("DiscountRate".into(), crate::money_market::quotes::discount_rate(price, face, days)));
+    measures.push(("MoneyMarketYield".into(), crate::money_market::quotes::money_market_yield(price, face, days)));
+    measures.push(("BondEquivalentYield".into(), crate::money_market::quotes::bond_equivalent_yield(price, face, days)));
+    measures.push(("EffectiveAnnualYield".into(), crate::money_market::quotes::effective_annual_yield(price, face, days)));
+    measures.push(("DollarDiscount".into(), crate::money_market::pricing::dollar_discount(price, face)));
+    measures.push(("HPR".into(), crate::money_market::pricing::holding_period_return(price, face)));
+
+    ValuationResult { measures, cashflows: vec![], errors: vec![] }
+}
+
+fn valuate_repo(input: &RepoInput) -> ValuationResult {
+    let spec = crate::repo::RepoSpec {
+        collateral_dirty_price: input.collateral_dirty_price,
+        collateral_face: input.collateral_face,
+        haircut: input.haircut,
+        repo_rate: input.repo_rate,
+        start_date: input.start_date,
+        end_date: input.end_date,
+        repo_type: crate::repo::RepoType::Term,
+    };
+
+    let mut measures = Vec::new();
+    measures.push(("CollateralMV".into(), crate::repo::pricing::collateral_market_value(&spec)));
+    measures.push(("LoanAmount".into(), crate::repo::pricing::loan_amount(&spec)));
+    measures.push(("RepoInterest".into(), crate::repo::pricing::repo_interest(&spec)));
+    measures.push(("RepurchasePrice".into(), crate::repo::pricing::repurchase_price(&spec)));
+    measures.push(("MarginRatio".into(), crate::repo::pricing::margin_ratio(&spec)));
+    measures.push(("BreakEvenPrice".into(), crate::repo::pricing::break_even_price(&spec)));
+
+    ValuationResult { measures, cashflows: vec![], errors: vec![] }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn d(y: i32, m: u32, day: u32) -> Date { Date::new(y, m, day) }
+
+    fn flat_curve(rate: f64) -> YieldCurve {
+        YieldCurve::new(d(2025, 1, 1), vec![0.5, 1.0, 2.0, 5.0, 10.0, 30.0], vec![rate; 6]).unwrap()
+    }
+
+    #[test]
+    fn dispatch_bond() {
+        let input = ProductInput::Bond(BondInput {
+            coupon_rate: 0.05, coupon_freq: 2, face_value: 100.0,
+            dated_date: d(2025, 1, 1), maturity_date: d(2035, 1, 1),
+            clean_price: 100.0, settlement: d(2025, 1, 1),
+            benchmark_curve: Some(flat_curve(0.04)), z_spread: 0.0,
+        });
+        let result = dispatch_valuation(&input, d(2025, 1, 1));
+        assert!(result.errors.is_empty());
+        let ytm = result.measures.iter().find(|(k,_)| k == "YieldToMaturity").unwrap().1;
+        assert!((ytm - 0.05).abs() < 1e-6);
+    }
+
+    #[test]
+    fn dispatch_swap() {
+        let curve = flat_curve(0.04);
+        let input = ProductInput::Swap(SwapInput {
+            notional: 1_000_000.0, fixed_rate: 0.04, fixed_freq: 2, float_freq: 4,
+            float_spread: 0.0, start_date: d(2025, 1, 1), maturity_date: d(2030, 1, 1),
+            pay_fixed: true, projection_curve: curve.clone(), discount_curve: curve,
+        });
+        let result = dispatch_valuation(&input, d(2025, 1, 1));
+        assert!(result.errors.is_empty());
+        let npv = result.measures.iter().find(|(k,_)| k == "NPV").unwrap().1;
+        assert!(npv.abs() < 1000.0);
+    }
+
+    #[test]
+    fn dispatch_money_market() {
+        let input = ProductInput::MoneyMarket(MoneyMarketInput {
+            face_value: 100.0, issue_date: d(2025, 1, 1), maturity_date: d(2025, 4, 1),
+            market_price: 98.75, settlement: d(2025, 1, 1), is_discount: true,
+        });
+        let result = dispatch_valuation(&input, d(2025, 1, 1));
+        let dr = result.measures.iter().find(|(k,_)| k == "DiscountRate").unwrap().1;
+        assert!(dr > 0.0);
+    }
+
+    #[test]
+    fn dispatch_repo() {
+        let input = ProductInput::Repo(RepoInput {
+            collateral_dirty_price: 101.5, collateral_face: 1_000_000.0,
+            haircut: 0.02, repo_rate: 0.05, start_date: d(2025, 1, 1), end_date: d(2025, 2, 1),
+        });
+        let result = dispatch_valuation(&input, d(2025, 1, 1));
+        let loan = result.measures.iter().find(|(k,_)| k == "LoanAmount").unwrap().1;
+        assert!(loan > 0.0);
+    }
+
+    #[test]
+    fn dispatch_mbs() {
+        let input = ProductInput::Mbs(MbsInput {
+            original_balance: 1_000_000.0, current_balance: 950_000.0,
+            pass_through_rate: 0.05, wac: 0.055, wam: 348, age: 12,
+            market_price: 98.0, psa_speed: 150.0, settlement: d(2025, 6, 1),
+        });
+        let result = dispatch_valuation(&input, d(2025, 6, 1));
+        let wal = result.measures.iter().find(|(k,_)| k == "WAL").unwrap().1;
+        assert!(wal > 0.0);
+    }
+}

--- a/valuation-calculator-rust/src/lib.rs
+++ b/valuation-calculator-rust/src/lib.rs
@@ -5,6 +5,7 @@ pub mod daycount;
 pub mod error;
 pub mod date;
 pub mod calculator;
+pub mod dispatch;
 pub mod swap;
 pub mod tips;
 pub mod muni;


### PR DESCRIPTION
## Summary
- Add `product_inputs.proto` defining a `ProductInput` oneof with 14 product-specific input messages (bond, callable bond, swap, MBS, money market, repo, TIPS, FRN, loan, futures, muni, xccy swap, amortizing bond, scenario) plus shared types (`YieldCurveInput`, `CurvePoint`).
- Extend `ValuationRequestProto` with a `ProductInput product_input = 70` field so the existing `RunValuation` RPC can dispatch based on which oneof variant is populated.
- Implement Rust `dispatch.rs` module with a `dispatch_valuation` function that pattern-matches on `ProductInput` variants and routes to the existing bond, swap, MBS, money market, and repo valuation modules, producing a unified `ValuationResult`.

## Test plan
- [x] `cargo check --tests` passes with no warnings
- [ ] Verify `dispatch_bond` test: par bond at coupon rate yields YTM matching coupon
- [ ] Verify `dispatch_swap` test: at-market swap has near-zero NPV
- [ ] Verify `dispatch_money_market` test: discount rate is positive for below-par price
- [ ] Verify `dispatch_repo` test: loan amount is positive with non-zero collateral
- [ ] Verify `dispatch_mbs` test: WAL is positive for seasoned MBS pool