### PR TITLE
Add TipsInput to ProductInput oneof (#183)

### DIFF
--- a/ledger-models-protos/fintekkers/requests/valuation/product_inputs.proto
+++ b/ledger-models-protos/fintekkers/requests/valuation/product_inputs.proto
@@ -25,6 +25,7 @@ option java_outer_classname = "ProductInputProtos";
 message ProductInput {
   oneof input {
     BondInput bond = 1;
+    TipsInput tips = 2;
     FrnInput frn = 8;
   }
 }
@@ -49,6 +50,31 @@ message BondInput {
   // benchmark securities and their market clean prices. The engine bootstraps
   // a zero-coupon spot curve internally. When omitted, Z-spread is not computed.
   SecurityBasedCurveInput benchmark_curve = 10;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// TipsInput — valuation request for a Treasury Inflation-Protected Security.
+//
+// Static security details (real coupon_rate, coupon_frequency, face_value,
+// maturity_date) are read from the SecurityProto.
+// Base CPI at issuance is read from SecurityProto.base_cpi.
+//
+// Settlement date is read from ValuationRequestProto.asof_datetime.
+// ═══════════════════════════════════════════════════════════════════════════
+message TipsInput {
+  // The TIPS security. Must be SecurityTypeProto.TIPS with coupon_type FIXED,
+  // all standard fixed-income fields populated, and base_cpi set to the
+  // reference CPI index value at issuance.
+  fintekkers.models.security.SecurityProto security = 1;
+
+  // Market clean price as a percentage of face value (e.g. 99.75 = 99.75% of par).
+  fintekkers.models.util.DecimalValueProto clean_price = 2;
+
+  // Current CPI index value (e.g. 310.326). Used to compute:
+  //   index_ratio = current_cpi / base_cpi
+  //   adjusted_principal = face_value * index_ratio
+  // The base CPI is read from security.base_cpi.
+  fintekkers.models.util.DecimalValueProto current_cpi = 3;
 }
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/ledger-models-rust/fintekkers.requests.valuation.rs
+++ b/ledger-models-rust/fintekkers.requests.valuation.rs
@@ -112,7 +112,7 @@ pub struct CurveResponseProto {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ProductInput {
-    #[prost(oneof = "product_input::Input", tags = "1, 8")]
+    #[prost(oneof = "product_input::Input", tags = "1, 2, 8")]
     pub input: ::core::option::Option<product_input::Input>,
 }
 /// Nested message and enum types in `ProductInput`.
@@ -122,6 +122,8 @@ pub mod product_input {
     pub enum Input {
         #[prost(message, tag = "1")]
         Bond(super::BondInput),
+        #[prost(message, tag = "2")]
+        Tips(super::TipsInput),
         #[prost(message, tag = "8")]
         Frn(super::FrnInput),
     }
@@ -151,6 +153,37 @@ pub struct BondInput {
     /// a zero-coupon spot curve internally. When omitted, Z-spread is not computed.
     #[prost(message, optional, tag = "10")]
     pub benchmark_curve: ::core::option::Option<SecurityBasedCurveInput>,
+}
+/// ═══════════════════════════════════════════════════════════════════════════
+/// TipsInput — valuation request for a Treasury Inflation-Protected Security.
+///
+/// Static security details (real coupon_rate, coupon_frequency, face_value,
+/// maturity_date) are read from the SecurityProto.
+/// Base CPI at issuance is read from SecurityProto.base_cpi.
+///
+/// Settlement date is read from ValuationRequestProto.asof_datetime.
+/// ═══════════════════════════════════════════════════════════════════════════
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct TipsInput {
+    /// The TIPS security. Must be SecurityTypeProto.TIPS with coupon_type FIXED,
+    /// all standard fixed-income fields populated, and base_cpi set to the
+    /// reference CPI index value at issuance.
+    #[prost(message, optional, tag = "1")]
+    pub security: ::core::option::Option<super::super::models::security::SecurityProto>,
+    /// Market clean price as a percentage of face value (e.g. 99.75 = 99.75% of par).
+    #[prost(message, optional, tag = "2")]
+    pub clean_price: ::core::option::Option<
+        super::super::models::util::DecimalValueProto,
+    >,
+    /// Current CPI index value (e.g. 310.326). Used to compute:
+    ///    index_ratio = current_cpi / base_cpi
+    ///    adjusted_principal = face_value * index_ratio
+    /// The base CPI is read from security.base_cpi.
+    #[prost(message, optional, tag = "3")]
+    pub current_cpi: ::core::option::Option<
+        super::super::models::util::DecimalValueProto,
+    >,
 }
 /// ═══════════════════════════════════════════════════════════════════════════
 /// FrnInput — valuation request for a Floating Rate Note.

--- a/ledger-models-rust/tests/tips_request_roundtrip_test.rs
+++ b/ledger-models-rust/tests/tips_request_roundtrip_test.rs
@@ -1,0 +1,187 @@
+//! Step 3 tests — TipsInput / ProductInput proto round-trips.
+//!
+//! For each field: construct → encode to bytes → decode → verify field matches.
+
+use ledger_models::fintekkers::models::security::{
+    CouponFrequencyProto, CouponTypeProto, SecurityProto, SecurityTypeProto,
+};
+use ledger_models::fintekkers::models::util::{DecimalValueProto, LocalDateProto};
+use ledger_models::fintekkers::requests::valuation::{
+    product_input, ProductInput, TipsInput, ValuationRequestProto,
+};
+use prost::Message;
+
+fn decimal(value: &str) -> DecimalValueProto {
+    DecimalValueProto { arbitrary_precision_value: value.to_string() }
+}
+
+fn date(year: u32, month: u32, day: u32) -> LocalDateProto {
+    LocalDateProto { year, month, day }
+}
+
+fn tips_security(base_cpi: &str) -> SecurityProto {
+    let mut sec = SecurityProto::default();
+    sec.security_type = SecurityTypeProto::Tips.into();
+    sec.coupon_type = CouponTypeProto::Fixed.into();
+    sec.coupon_frequency = CouponFrequencyProto::Semiannually.into();
+    sec.face_value = Some(decimal("1000"));
+    sec.coupon_rate = Some(decimal("0.625"));
+    sec.maturity_date = Some(date(2030, 1, 15));
+    sec.base_cpi = Some(decimal(base_cpi));
+    sec
+}
+
+fn roundtrip_product_input(original: &ProductInput) -> ProductInput {
+    let mut buf = Vec::new();
+    original.encode(&mut buf).expect("encode failed");
+    ProductInput::decode(&buf[..]).expect("decode failed")
+}
+
+fn roundtrip_valuation_request(original: &ValuationRequestProto) -> ValuationRequestProto {
+    let mut buf = Vec::new();
+    original.encode(&mut buf).expect("encode failed");
+    ValuationRequestProto::decode(&buf[..]).expect("decode failed")
+}
+
+#[test]
+fn tips_input_clean_price_survives_roundtrip() {
+    let tips = TipsInput {
+        security: Some(tips_security("260.474")),
+        clean_price: Some(decimal("97.50")),
+        current_cpi: Some(decimal("310.326")),
+    };
+    let original = ProductInput {
+        input: Some(product_input::Input::Tips(tips)),
+    };
+
+    let parsed = roundtrip_product_input(&original);
+
+    match parsed.input.unwrap() {
+        product_input::Input::Tips(t) => {
+            assert_eq!(t.clean_price.unwrap().arbitrary_precision_value, "97.50");
+        }
+        other => panic!("Expected Tips variant, got {:?}", other),
+    }
+}
+
+#[test]
+fn tips_input_current_cpi_survives_roundtrip() {
+    let tips = TipsInput {
+        security: Some(tips_security("260.474")),
+        clean_price: Some(decimal("97.50")),
+        current_cpi: Some(decimal("310.326")),
+    };
+    let original = ProductInput {
+        input: Some(product_input::Input::Tips(tips)),
+    };
+
+    let parsed = roundtrip_product_input(&original);
+
+    match parsed.input.unwrap() {
+        product_input::Input::Tips(t) => {
+            assert_eq!(t.current_cpi.unwrap().arbitrary_precision_value, "310.326");
+        }
+        other => panic!("Expected Tips variant, got {:?}", other),
+    }
+}
+
+#[test]
+fn tips_input_security_fields_survive_roundtrip() {
+    let tips = TipsInput {
+        security: Some(tips_security("260.474")),
+        clean_price: Some(decimal("97.50")),
+        current_cpi: Some(decimal("310.326")),
+    };
+    let original = ProductInput {
+        input: Some(product_input::Input::Tips(tips)),
+    };
+
+    let parsed = roundtrip_product_input(&original);
+
+    match parsed.input.unwrap() {
+        product_input::Input::Tips(t) => {
+            let sec = t.security.unwrap();
+            assert_eq!(sec.security_type(), SecurityTypeProto::Tips);
+            assert_eq!(sec.coupon_type(), CouponTypeProto::Fixed);
+            assert_eq!(sec.coupon_frequency(), CouponFrequencyProto::Semiannually);
+            assert_eq!(sec.coupon_rate.unwrap().arbitrary_precision_value, "0.625");
+            assert_eq!(sec.face_value.unwrap().arbitrary_precision_value, "1000");
+            assert_eq!(sec.base_cpi.unwrap().arbitrary_precision_value, "260.474");
+            let mat = sec.maturity_date.unwrap();
+            assert_eq!(mat.year, 2030);
+            assert_eq!(mat.month, 1);
+            assert_eq!(mat.day, 15);
+        }
+        other => panic!("Expected Tips variant, got {:?}", other),
+    }
+}
+
+#[test]
+fn valuation_request_with_tips_product_input_survives_roundtrip() {
+    let tips = TipsInput {
+        security: Some(tips_security("260.474")),
+        clean_price: Some(decimal("97.50")),
+        current_cpi: Some(decimal("310.326")),
+    };
+    let original = ValuationRequestProto {
+        object_class: "ValuationRequest".into(),
+        version: "0.0.1".into(),
+        product_input: Some(ProductInput {
+            input: Some(product_input::Input::Tips(tips)),
+        }),
+        ..Default::default()
+    };
+
+    let parsed = roundtrip_valuation_request(&original);
+
+    assert_eq!(parsed.object_class, "ValuationRequest");
+    let pi = parsed.product_input.unwrap();
+    match pi.input.unwrap() {
+        product_input::Input::Tips(t) => {
+            assert_eq!(t.clean_price.unwrap().arbitrary_precision_value, "97.50");
+            assert_eq!(t.current_cpi.unwrap().arbitrary_precision_value, "310.326");
+        }
+        other => panic!("Expected Tips variant, got {:?}", other),
+    }
+}
+
+#[test]
+fn tips_is_distinct_from_bond_oneof_variant() {
+    let tips = TipsInput {
+        security: Some(tips_security("260.474")),
+        clean_price: Some(decimal("97.50")),
+        current_cpi: Some(decimal("310.326")),
+    };
+    let original = ProductInput {
+        input: Some(product_input::Input::Tips(tips)),
+    };
+    let parsed = roundtrip_product_input(&original);
+    assert!(
+        matches!(parsed.input, Some(product_input::Input::Tips(_))),
+        "TipsInput ProductInput must decode as Tips, not Bond or other variant"
+    );
+}
+
+#[test]
+fn tips_index_ratio_fields_preserve_precision() {
+    // Verifies that high-precision CPI values (used in index_ratio computation)
+    // survive encode/decode without loss.
+    let tips = TipsInput {
+        security: Some(tips_security("260.47400")),
+        clean_price: Some(decimal("98.765432")),
+        current_cpi: Some(decimal("310.32600")),
+    };
+    let original = ProductInput {
+        input: Some(product_input::Input::Tips(tips)),
+    };
+    let parsed = roundtrip_product_input(&original);
+
+    match parsed.input.unwrap() {
+        product_input::Input::Tips(t) => {
+            assert_eq!(t.current_cpi.unwrap().arbitrary_precision_value, "310.32600");
+            let sec = t.security.unwrap();
+            assert_eq!(sec.base_cpi.unwrap().arbitrary_precision_value, "260.47400");
+        }
+        other => panic!("Expected Tips variant, got {:?}", other),
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `TipsInput` message at field 2 in the `ProductInput` oneof (within the 1–7 fixed-income reservation)
- `TipsInput` carries `security` (with `base_cpi` from SecurityProto), `clean_price`, and `current_cpi` — sufficient for the valuation engine to compute index_ratio, adjusted_principal, real_yield, and all standard TIPS measures
- 6 proto round-trip tests in `tests/tips_request_roundtrip_test.rs` covering all fields, the full `ValuationRequestProto` round-trip, Tips/Bond variant isolation, and CPI precision preservation

## Test plan

- [x] `cargo build` passes
- [x] `cargo test --test tips_request_roundtrip_test` — 6 tests pass
- [x] Existing bond and FRN round-trip tests unaffected

## Context

FinTekkers/second-brain#183 — Step 4

🤖 Generated with [Claude Code](https://claude.com/claude-code)