### PR TITLE
Add SERIES_ID to IdentifierType domain enum (#190)

### DIFF
--- a/ledger-models-java/src/main/java/common/models/security/identifier/IdentifierType.java
+++ b/ledger-models-java/src/main/java/common/models/security/identifier/IdentifierType.java
@@ -6,5 +6,6 @@ public enum IdentifierType {
     CUSIP,
     OSI,
     FIGI,
+    SERIES_ID,
     CASH
 }

--- a/ledger-models-java/src/test/java/protos/serializers/security/IdentifierSerializerTest.java
+++ b/ledger-models-java/src/test/java/protos/serializers/security/IdentifierSerializerTest.java
@@ -21,4 +21,19 @@ class IdentifierSerializerTest {
 
         Assertions.assertEquals(id, idCopy);
     }
+
+    @Test
+    public void seriesIdRoundTrip() {
+        Identifier id = new Identifier(IdentifierType.SERIES_ID, "CUUR0000SA0");
+
+        IdentifierSerializer serializer = IdentifierSerializer.getInstance();
+
+        IdentifierProto proto = serializer.serialize(id);
+        String json = serializer.serializeToJson(proto);
+
+        IdentifierProto protoCopy = serializer.deserializeFromJson(json);
+        Identifier idCopy = serializer.deserialize(protoCopy);
+
+        Assertions.assertEquals(id, idCopy);
+    }
 }


### PR DESCRIPTION
Fixes [FinTekkers/second-brain#190](https://github.com/FinTekkers/second-brain/issues/190).

## Summary

The proto-generated `IdentifierTypeProto` (regenerated 2026-03-23) already has `SERIES_ID = 6`, but the hand-written domain enum at `common.models.security.identifier.IdentifierType` was never updated to match.

`IdentifierSerializer.deserialize()` (`IdentifierSerializer.java:71`) calls `IdentifierType.valueOf(proto.getIdentifierType().name())`, which threw `IllegalArgumentException: No enum constant ... IdentifierType.SERIES_ID` for any `SecurityProto` whose identifier type was `SERIES_ID`. That blocked `SecurityService.createOrUpdate` for the BLS CPI loader (and other macro sources keyed off series IDs).

## Change

- Add `SERIES_ID` to `common.models.security.identifier.IdentifierType`.
- Add a round-trip test mirroring the existing CUSIP one.

## Verification

A standalone Java program against the rebuilt jar exercises the exact failing path:

```
Proto identifier_type name:   SERIES_ID
Proto identifier_type number: 6
Deserialized OK: type=SERIES_ID value=CUUR0000SA0
JSON round-trip OK: type=SERIES_ID value=CUUR0000SA0
```

`ledger-service` was rebuilt against the new jar (`./gradlew :subledger:run`) and started cleanly on `:8082`.

## Notes

- The new test is in place but `:test` cannot currently compile due to a pre-existing breakage in `FrnRequestRoundtripTest.java` (missing symbols from `fintekkers.models.util.DecimalValueProtos` / `LocalDateProtos`) — unrelated to this PR. The build itself (`./gradlew build -x test`) is green.
- I did **not** include the regenerated `generated-src/**` proto Java files that appeared in my working tree after running the gradle build — those look unrelated (FRN/TIPS/IndexType updates) and should be a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)