### PR TITLE
Add compile.sh gate: PR check that proto bindings match sources (#192)

### DIFF
--- a/.github/workflows/compile-sh-gate.yml
+++ b/.github/workflows/compile-sh-gate.yml
@@ -1,0 +1,77 @@
+name: compile.sh gate
+
+# Runs ./compile.sh --skip-integration on every PR and fails if either:
+#   1. the script exits non-zero, OR
+#   2. `git status --porcelain` is non-empty after the run (i.e. the committed
+#      generated bindings drifted from the .proto sources, or new tsc artifacts
+#      / Python pyi / Rust descriptor outputs weren't staged).
+#
+# This catches the partial-regen pattern documented in
+# FinTekkers/second-brain#192 — proto edit committed without the full set of
+# regenerated outputs across all four language targets.
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  compile-sh:
+    name: ./compile.sh --skip-integration + clean git status
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Set up Node.js 16
+        uses: actions/setup-node@v4
+        with:
+          node-version: '16.x'
+
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.9'
+
+      - name: Install Rust stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - name: Install protoc + grpc_node_plugin
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler protobuf-compiler-grpc
+          protoc --version
+          which grpc_node_plugin
+
+      - name: npm ci (ledger-models-javascript)
+        working-directory: ledger-models-javascript
+        run: npm ci
+
+      - name: Run ./compile.sh --skip-integration
+        run: ./compile.sh --skip-integration
+
+      - name: Verify git status is clean
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "::error::./compile.sh --skip-integration produced uncommitted changes."
+            echo "::error::This means the committed generated bindings have drifted from the .proto sources,"
+            echo "::error::or new generated/test artifacts were not staged. See README.md DevOps section."
+            echo ""
+            echo "=== git status ==="
+            git status
+            echo ""
+            echo "=== git diff (tracked files) ==="
+            git --no-pager diff
+            exit 1
+          fi
+          echo "git status is clean — proto bindings match .proto sources."


### PR DESCRIPTION
Closes the devops piece of [FinTekkers/second-brain#192](https://github.com/FinTekkers/second-brain/issues/192). Follows up on [#175](https://github.com/FinTekkers/ledger-models/pull/175) (the baseline regen).

## What this adds

`.github/workflows/compile-sh-gate.yml` — a single-job workflow that on every PR to main (and push to main):

1. Sets up JDK 17 (matches `ledger-models-java/build.gradle` `sourceCompatibility`), Node 16, Python 3.9, Rust stable.
2. Installs `protoc` + `grpc_node_plugin` via apt (`protobuf-compiler`, `protobuf-compiler-grpc`).
3. `npm ci` in `ledger-models-javascript` (locks tsc + protoc-gen-ts to package-lock).
4. Runs `./compile.sh --skip-integration`.
5. Fails if `git status --porcelain` is non-empty afterwards, dumping the full `git status` + `git diff` so the contributor sees exactly which generated files they need to stage.

## Why both checks

- `./compile.sh` exit ≠ 0 catches genuine compile/test breaks across the four languages.
- `git status` non-empty catches the *partial regen* case described in #192: proto edit committed without the corresponding regenerated outputs. This is the failure mode that landed `TipsInput` missing from `ProductInput` oneof on JS/Python/Rust even though the Java side was up to date.

## Triggers

- `pull_request` to `main` — the gate.
- `push` to `main` — post-merge safety net so we notice immediately if a merge somehow breaks the baseline.

## Toolchain notes

- **protoc version**: apt's `protobuf-compiler` on ubuntu-latest is older than the local Homebrew protoc 34.0. JS-generated `_pb.js` / `_pb.d.ts` files don't carry protoc-version comments (verified), so this should be stable. If a future PR triggers a false-positive diff that traces to protoc version drift, the fix is to swap `apt-get install` for `arduino/setup-protoc@v3` with a pinned version.
- **Python `grpcio-tools`**: `compile.sh` self-bootstraps the venv and `pip install grpcio-tools` without a version pin. If a new release of grpcio-tools changes generated `_pb2.py` output, the gate will start failing on PRs that didn't change anything. Pin in `compile.sh` if that happens.
- **No caching**: first iteration prioritizes correctness over speed. Add cargo / gradle / npm caches if the workflow runtime becomes a bottleneck.

## Out of scope (PM action needed)

- **Making this a required status check** that *blocks* merge is a branch-protection setting on the repo, not something a workflow file can do. Once this PR is green, PM should flip:
  Settings → Branches → main → \"Require status checks to pass\" → add `./compile.sh --skip-integration + clean git status`.

## Test plan

- [ ] Workflow runs on this PR's commit and is green (it self-tests — the workflow file is in this PR).
- [ ] Run completes in < ~10 min on ubuntu-latest.
- [ ] After merge, the next PR that touches a `.proto` without regenerating gets a red check (manual smoke test or wait for it to happen organically).

🤖 Generated with [Claude Code](https://claude.com/claude-code)