### PR TITLE
java: LinkResolver utility (#196)

### DIFF
--- a/ledger-models-java/src/main/java/common/util/LinkResolver.java
+++ b/ledger-models-java/src/main/java/common/util/LinkResolver.java
@@ -1,0 +1,447 @@
+package common.util;
+
+import fintekkers.models.portfolio.PortfolioProto;
+import fintekkers.models.security.SecurityProto;
+import fintekkers.models.transaction.TransactionProto;
+import fintekkers.models.util.LocalTimestamp.LocalTimestampProto;
+import fintekkers.models.util.Uuid.UUIDProto;
+import fintekkers.models.price.PriceProto;
+import fintekkers.requests.portfolio.QueryPortfolioRequestProto;
+import fintekkers.requests.portfolio.QueryPortfolioResponseProto;
+import fintekkers.requests.security.QuerySecurityRequestProto;
+import fintekkers.requests.security.QuerySecurityResponseProto;
+import fintekkers.services.portfolio_service.PortfolioGrpc;
+import fintekkers.services.security_service.SecurityGrpc;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * LinkResolver — bulk hydration of {@code is_link=true} entity references
+ * into full entities. Java parity for the JS / Python implementations
+ * shipped in #181 / #183. Implements the consumer side of the {@code is_link}
+ * pattern documented in {@code docs/adr/is_link_pattern.md} (and the
+ * technical-details addendum that codifies the (uuid, as_of) cache key +
+ * per-bucket batching contract).
+ *
+ * <p>Surface:
+ * <ul>
+ *   <li>{@link #getSecurity(UUID)} / {@link #getSecurity(UUID, LocalTimestampProto)}
+ *       and the portfolio counterparts — single-UUID resolution, cached and
+ *       concurrent-deduped on (uuid, as_of).</li>
+ *   <li>{@link #resolveSecuritiesOnPrices(List)},
+ *       {@link #resolveSecuritiesOnTransactions(List)},
+ *       {@link #resolvePortfoliosOnTransactions(List)} — bulk hydrate. Java
+ *       protobuf messages are immutable, so these return a NEW list with
+ *       hydrated copies; the input list is not mutated. Items whose embedded
+ *       sub-message is already a full entity pass through unchanged.</li>
+ * </ul>
+ *
+ * <p>Why batch by {@code as_of}: {@code GetByIds} carries a single
+ * {@code as_of} per request, so a heterogeneous result set (e.g. a backtest
+ * result with mixed timestamps) must group by {@code as_of} bucket and fire
+ * one RPC per bucket. The cache is keyed on (uuid, as_of) so the same UUID
+ * at different timestamps does not alias.
+ *
+ * <p>Test injection: pass {@link SecurityFetcher} / {@link PortfolioFetcher}
+ * implementations into the constructor to mock the gRPC layer in unit tests.
+ * Production callers leave them null and the resolver builds blocking stubs
+ * against the configured endpoint.
+ */
+public class LinkResolver {
+
+    /** Functional-interface seam for testability. The default impl wraps
+     * {@code SecurityBlockingStub.getByIds}; tests inject a fake. */
+    @FunctionalInterface
+    public interface SecurityFetcher {
+        QuerySecurityResponseProto getByIds(QuerySecurityRequestProto request);
+    }
+
+    @FunctionalInterface
+    public interface PortfolioFetcher {
+        QueryPortfolioResponseProto getByIds(QueryPortfolioRequestProto request);
+    }
+
+    private static final String LATEST_BUCKET = "latest";
+
+    private final SecurityFetcher securityFetcher;
+    private final PortfolioFetcher portfolioFetcher;
+
+    private final TinyLRU<SecurityProto> securityCache;
+    private final TinyLRU<PortfolioProto> portfolioCache;
+
+    private final ConcurrentHashMap<String, CompletableFuture<SecurityProto>> securityInFlight
+            = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, CompletableFuture<PortfolioProto>> portfolioInFlight
+            = new ConcurrentHashMap<>();
+
+    /** Default constructor: blocking stubs against the configured endpoint.
+     * 1000-entry LRU, no TTL. */
+    public LinkResolver(String url, int port, boolean isHttp) {
+        this(buildSecurityFetcher(url, port, isHttp),
+             buildPortfolioFetcher(url, port, isHttp),
+             1000, 0);
+    }
+
+    /** Test / advanced constructor.
+     *
+     * @param securityFetcher  inject a fake here in tests
+     * @param portfolioFetcher inject a fake here in tests
+     * @param cacheSize        LRU max entries; 0 disables caching
+     * @param ttlMillis        per-entry TTL in ms; 0 = no expiry
+     */
+    public LinkResolver(SecurityFetcher securityFetcher,
+                        PortfolioFetcher portfolioFetcher,
+                        int cacheSize,
+                        long ttlMillis) {
+        this.securityFetcher = securityFetcher;
+        this.portfolioFetcher = portfolioFetcher;
+        this.securityCache = new TinyLRU<>(cacheSize, ttlMillis);
+        this.portfolioCache = new TinyLRU<>(cacheSize, ttlMillis);
+    }
+
+    private static SecurityFetcher buildSecurityFetcher(String url, int port, boolean isHttp) {
+        ManagedChannelBuilder<?> builder = ManagedChannelBuilder.forAddress(url, port);
+        if (isHttp) builder.usePlaintext();
+        ManagedChannel channel = builder.build();
+        SecurityGrpc.SecurityBlockingStub stub = SecurityGrpc.newBlockingStub(channel);
+        return stub::getByIds;
+    }
+
+    private static PortfolioFetcher buildPortfolioFetcher(String url, int port, boolean isHttp) {
+        ManagedChannelBuilder<?> builder = ManagedChannelBuilder.forAddress(url, port);
+        if (isHttp) builder.usePlaintext();
+        ManagedChannel channel = builder.build();
+        PortfolioGrpc.PortfolioBlockingStub stub = PortfolioGrpc.newBlockingStub(channel);
+        return stub::getByIds;
+    }
+
+    // ---------- single-UUID accessors ----------
+
+    public SecurityProto getSecurity(UUID uuid) {
+        return getSecurity(uuid, null);
+    }
+
+    public SecurityProto getSecurity(UUID uuid, LocalTimestampProto asOf) {
+        String key = cacheKey(uuid, asOf);
+        SecurityProto cached = securityCache.get(key);
+        if (cached != null) return cached;
+
+        // Concurrent-call dedup: putIfAbsent decides who gets to do the fetch.
+        CompletableFuture<SecurityProto> existing = securityInFlight.get(key);
+        if (existing != null) return joinUnchecked(existing);
+
+        CompletableFuture<SecurityProto> created = new CompletableFuture<>();
+        CompletableFuture<SecurityProto> winner = securityInFlight.putIfAbsent(key, created);
+        if (winner != null) return joinUnchecked(winner);
+
+        try {
+            List<SecurityProto> protos = batchFetchSecurities(List.of(uuid), asOf);
+            if (protos.isEmpty()) {
+                IllegalStateException e = new IllegalStateException(
+                        "Security not found: " + key);
+                created.completeExceptionally(e);
+                throw e;
+            }
+            SecurityProto proto = protos.get(0);
+            securityCache.set(key, proto);
+            created.complete(proto);
+            return proto;
+        } finally {
+            securityInFlight.remove(key);
+        }
+    }
+
+    public PortfolioProto getPortfolio(UUID uuid) {
+        return getPortfolio(uuid, null);
+    }
+
+    public PortfolioProto getPortfolio(UUID uuid, LocalTimestampProto asOf) {
+        String key = cacheKey(uuid, asOf);
+        PortfolioProto cached = portfolioCache.get(key);
+        if (cached != null) return cached;
+
+        CompletableFuture<PortfolioProto> existing = portfolioInFlight.get(key);
+        if (existing != null) return joinUnchecked(existing);
+
+        CompletableFuture<PortfolioProto> created = new CompletableFuture<>();
+        CompletableFuture<PortfolioProto> winner = portfolioInFlight.putIfAbsent(key, created);
+        if (winner != null) return joinUnchecked(winner);
+
+        try {
+            List<PortfolioProto> protos = batchFetchPortfolios(List.of(uuid), asOf);
+            if (protos.isEmpty()) {
+                IllegalStateException e = new IllegalStateException(
+                        "Portfolio not found: " + key);
+                created.completeExceptionally(e);
+                throw e;
+            }
+            PortfolioProto proto = protos.get(0);
+            portfolioCache.set(key, proto);
+            created.complete(proto);
+            return proto;
+        } finally {
+            portfolioInFlight.remove(key);
+        }
+    }
+
+    // ---------- bulk accessors ----------
+
+    /** Hydrate the embedded security on each Price. Returns a NEW list —
+     * Java protobufs are immutable so we can't mutate in place; PriceProto.toBuilder()
+     * is used to swap the security sub-message and rebuild. Items whose embedded
+     * security is not a link, or which have no security set, pass through unchanged. */
+    public List<PriceProto> resolveSecuritiesOnPrices(List<PriceProto> prices) {
+        ensureSecuritiesCached(prices, PriceProto::hasSecurity, PriceProto::getSecurity);
+        List<PriceProto> out = new ArrayList<>(prices.size());
+        for (PriceProto p : prices) {
+            if (!p.hasSecurity() || !p.getSecurity().getIsLink()) {
+                out.add(p);
+                continue;
+            }
+            SecurityProto resolved = lookupResolvedSecurity(p.getSecurity());
+            if (resolved == null) {
+                out.add(p);
+            } else {
+                out.add(p.toBuilder().setSecurity(resolved).build());
+            }
+        }
+        return out;
+    }
+
+    /** Same shape as resolveSecuritiesOnPrices, for embedded security on Transaction. */
+    public List<TransactionProto> resolveSecuritiesOnTransactions(List<TransactionProto> txns) {
+        ensureSecuritiesCached(txns, TransactionProto::hasSecurity, TransactionProto::getSecurity);
+        List<TransactionProto> out = new ArrayList<>(txns.size());
+        for (TransactionProto t : txns) {
+            if (!t.hasSecurity() || !t.getSecurity().getIsLink()) {
+                out.add(t);
+                continue;
+            }
+            SecurityProto resolved = lookupResolvedSecurity(t.getSecurity());
+            if (resolved == null) {
+                out.add(t);
+            } else {
+                out.add(t.toBuilder().setSecurity(resolved).build());
+            }
+        }
+        return out;
+    }
+
+    /** Hydrate the embedded portfolio on each Transaction. */
+    public List<TransactionProto> resolvePortfoliosOnTransactions(List<TransactionProto> txns) {
+        ensurePortfoliosCached(txns);
+        List<TransactionProto> out = new ArrayList<>(txns.size());
+        for (TransactionProto t : txns) {
+            if (!t.hasPortfolio() || !t.getPortfolio().getIsLink()) {
+                out.add(t);
+                continue;
+            }
+            PortfolioProto resolved = lookupResolvedPortfolio(t.getPortfolio());
+            if (resolved == null) {
+                out.add(t);
+            } else {
+                out.add(t.toBuilder().setPortfolio(resolved).build());
+            }
+        }
+        return out;
+    }
+
+    // ---------- internals ----------
+
+    /** Walk items, group link UUIDs by as_of, fire one batched GetByIds per
+     * bucket, populate the security cache. */
+    private <T> void ensureSecuritiesCached(
+            List<T> items,
+            java.util.function.Predicate<T> hasSec,
+            java.util.function.Function<T, SecurityProto> getSec) {
+        // bucketKey -> list of UUIDs (deduped) for that as_of
+        Map<String, Map<String, UUID>> buckets = new HashMap<>();
+        Map<String, LocalTimestampProto> bucketAsOfs = new HashMap<>();
+        for (T item : items) {
+            if (!hasSec.test(item)) continue;
+            SecurityProto sec = getSec.apply(item);
+            if (!sec.getIsLink()) continue;
+            UUID uuid = uuidFromProto(sec.getUuid());
+            LocalTimestampProto asOf = sec.hasAsOf() ? sec.getAsOf() : null;
+            String bucketKey = bucketKey(asOf);
+            String cacheKey = cacheKey(uuid, asOf);
+            if (securityCache.get(cacheKey) != null) continue;
+            buckets.computeIfAbsent(bucketKey, k -> new HashMap<>()).putIfAbsent(cacheKey, uuid);
+            bucketAsOfs.put(bucketKey, asOf);
+        }
+        for (Map.Entry<String, Map<String, UUID>> entry : buckets.entrySet()) {
+            String bucketKey = entry.getKey();
+            Collection<UUID> uuids = entry.getValue().values();
+            LocalTimestampProto asOf = bucketAsOfs.get(bucketKey);
+            List<SecurityProto> fetched = batchFetchSecurities(uuids, asOf);
+            for (SecurityProto p : fetched) {
+                UUID u = uuidFromProto(p.getUuid());
+                securityCache.set(cacheKey(u, asOf), p);
+            }
+        }
+    }
+
+    /** Same as ensureSecuritiesCached but for Transaction.portfolio. */
+    private void ensurePortfoliosCached(List<TransactionProto> items) {
+        Map<String, Map<String, UUID>> buckets = new HashMap<>();
+        Map<String, LocalTimestampProto> bucketAsOfs = new HashMap<>();
+        for (TransactionProto t : items) {
+            if (!t.hasPortfolio()) continue;
+            PortfolioProto port = t.getPortfolio();
+            if (!port.getIsLink()) continue;
+            UUID uuid = uuidFromProto(port.getUuid());
+            LocalTimestampProto asOf = port.hasAsOf() ? port.getAsOf() : null;
+            String bucketKey = bucketKey(asOf);
+            String cacheKey = cacheKey(uuid, asOf);
+            if (portfolioCache.get(cacheKey) != null) continue;
+            buckets.computeIfAbsent(bucketKey, k -> new HashMap<>()).putIfAbsent(cacheKey, uuid);
+            bucketAsOfs.put(bucketKey, asOf);
+        }
+        for (Map.Entry<String, Map<String, UUID>> entry : buckets.entrySet()) {
+            String bucketKey = entry.getKey();
+            Collection<UUID> uuids = entry.getValue().values();
+            LocalTimestampProto asOf = bucketAsOfs.get(bucketKey);
+            List<PortfolioProto> fetched = batchFetchPortfolios(uuids, asOf);
+            for (PortfolioProto p : fetched) {
+                UUID u = uuidFromProto(p.getUuid());
+                portfolioCache.set(cacheKey(u, asOf), p);
+            }
+        }
+    }
+
+    private SecurityProto lookupResolvedSecurity(SecurityProto link) {
+        UUID uuid = uuidFromProto(link.getUuid());
+        LocalTimestampProto asOf = link.hasAsOf() ? link.getAsOf() : null;
+        return securityCache.get(cacheKey(uuid, asOf));
+    }
+
+    private PortfolioProto lookupResolvedPortfolio(PortfolioProto link) {
+        UUID uuid = uuidFromProto(link.getUuid());
+        LocalTimestampProto asOf = link.hasAsOf() ? link.getAsOf() : null;
+        return portfolioCache.get(cacheKey(uuid, asOf));
+    }
+
+    private List<SecurityProto> batchFetchSecurities(Collection<UUID> uuids, LocalTimestampProto asOf) {
+        if (uuids.isEmpty()) return List.of();
+        QuerySecurityRequestProto.Builder b = QuerySecurityRequestProto.newBuilder()
+                .setObjectClass("SecurityRequest")
+                .setVersion("0.0.1");
+        for (UUID u : uuids) b.addUuIds(uuidToProto(u));
+        if (asOf != null) b.setAsOf(asOf);
+        QuerySecurityResponseProto response = securityFetcher.getByIds(b.build());
+        return response.getSecurityResponseList();
+    }
+
+    private List<PortfolioProto> batchFetchPortfolios(Collection<UUID> uuids, LocalTimestampProto asOf) {
+        if (uuids.isEmpty()) return List.of();
+        QueryPortfolioRequestProto.Builder b = QueryPortfolioRequestProto.newBuilder()
+                .setObjectClass("PortfolioRequest")
+                .setVersion("0.0.1");
+        for (UUID u : uuids) b.addUuIds(uuidToProto(u));
+        if (asOf != null) b.setAsOf(asOf);
+        QueryPortfolioResponseProto response = portfolioFetcher.getByIds(b.build());
+        return response.getPortfolioResponseList();
+    }
+
+    private static String bucketKey(LocalTimestampProto asOf) {
+        if (asOf == null) return LATEST_BUCKET;
+        return Base64.getEncoder().encodeToString(asOf.toByteArray());
+    }
+
+    private static String cacheKey(UUID uuid, LocalTimestampProto asOf) {
+        return uuid.toString() + "@" + bucketKey(asOf);
+    }
+
+    private static UUID uuidFromProto(UUIDProto proto) {
+        byte[] raw = proto.getRawUuid().toByteArray();
+        java.nio.ByteBuffer bb = java.nio.ByteBuffer.wrap(raw);
+        long high = bb.getLong();
+        long low = bb.getLong();
+        return new UUID(high, low);
+    }
+
+    private static UUIDProto uuidToProto(UUID uuid) {
+        java.nio.ByteBuffer bb = java.nio.ByteBuffer.allocate(16);
+        bb.putLong(uuid.getMostSignificantBits());
+        bb.putLong(uuid.getLeastSignificantBits());
+        return UUIDProto.newBuilder()
+                .setRawUuid(com.google.protobuf.ByteString.copyFrom(bb.array()))
+                .build();
+    }
+
+    private static <T> T joinUnchecked(CompletableFuture<T> f) {
+        try {
+            return f.get();
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(ie);
+        } catch (Exception e) {
+            if (e.getCause() instanceof RuntimeException) throw (RuntimeException) e.getCause();
+            throw new RuntimeException(e);
+        }
+    }
+
+    /** Test/debug helper. */
+    public void clearCache() {
+        securityCache.clear();
+        portfolioCache.clear();
+    }
+
+    /** Tiny LRU. {@code synchronized} on {@code LinkedHashMap} for thread
+     * safety; access-order so {@code get} bumps to most-recently-used.
+     * {@code removeEldestEntry} caps the size automatically. */
+    private static final class TinyLRU<V> {
+        private final int maxSize;
+        private final long ttlMillis;
+        private final LinkedHashMap<String, Entry<V>> data;
+
+        TinyLRU(int maxSize, long ttlMillis) {
+            this.maxSize = maxSize;
+            this.ttlMillis = ttlMillis;
+            this.data = new LinkedHashMap<>(16, 0.75f, /* accessOrder = */ true) {
+                @Override
+                protected boolean removeEldestEntry(Map.Entry<String, Entry<V>> eldest) {
+                    return TinyLRU.this.maxSize > 0 && size() > TinyLRU.this.maxSize;
+                }
+            };
+        }
+
+        synchronized V get(String key) {
+            if (maxSize == 0) return null;
+            Entry<V> entry = data.get(key);
+            if (entry == null) return null;
+            if (ttlMillis > 0 && System.currentTimeMillis() - entry.insertedAt > ttlMillis) {
+                data.remove(key);
+                return null;
+            }
+            return entry.value;
+        }
+
+        synchronized void set(String key, V value) {
+            if (maxSize == 0) return;
+            data.put(key, new Entry<>(value, System.currentTimeMillis()));
+        }
+
+        synchronized void clear() {
+            data.clear();
+        }
+
+        private static final class Entry<V> {
+            final V value;
+            final long insertedAt;
+            Entry(V value, long insertedAt) { this.value = value; this.insertedAt = insertedAt; }
+        }
+    }
+}

--- a/ledger-models-java/src/test/java/common/util/LinkResolverTest.java
+++ b/ledger-models-java/src/test/java/common/util/LinkResolverTest.java
@@ -1,0 +1,409 @@
+package common.util;
+
+import com.google.protobuf.ByteString;
+import com.google.protobuf.Timestamp;
+import fintekkers.models.portfolio.PortfolioProto;
+import fintekkers.models.price.PriceProto;
+import fintekkers.models.security.IdentifierProto;
+import fintekkers.models.security.SecurityProto;
+import fintekkers.models.transaction.TransactionProto;
+import fintekkers.models.util.LocalTimestamp.LocalTimestampProto;
+import fintekkers.models.util.Uuid.UUIDProto;
+import fintekkers.requests.portfolio.QueryPortfolioRequestProto;
+import fintekkers.requests.portfolio.QueryPortfolioResponseProto;
+import fintekkers.requests.security.QuerySecurityRequestProto;
+import fintekkers.requests.security.QuerySecurityResponseProto;
+import org.junit.jupiter.api.Test;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link LinkResolver}. Mocks the {@link LinkResolver.SecurityFetcher}
+ * and {@link LinkResolver.PortfolioFetcher} seams to avoid any gRPC over the wire.
+ */
+class LinkResolverTest {
+
+    // ---------- helpers ----------
+
+    /** Recording fetcher that satisfies queries from a UUID->Proto store and
+     * logs each call for assertion. */
+    private static final class RecordingSecurityFetcher implements LinkResolver.SecurityFetcher {
+        final Map<String, SecurityProto> store;
+        int callCount = 0;
+        final List<List<String>> requestedUuids = new ArrayList<>();
+        final List<Long> requestedAsOfSeconds = new ArrayList<>(); // null seconds → -1
+
+        RecordingSecurityFetcher(Map<String, SecurityProto> store) { this.store = store; }
+
+        @Override
+        public QuerySecurityResponseProto getByIds(QuerySecurityRequestProto request) {
+            callCount++;
+            List<String> uids = new ArrayList<>();
+            for (UUIDProto u : request.getUuIdsList()) uids.add(uuidStrFromProto(u));
+            requestedUuids.add(uids);
+            requestedAsOfSeconds.add(request.hasAsOf() ? request.getAsOf().getTimestamp().getSeconds() : -1L);
+            QuerySecurityResponseProto.Builder b = QuerySecurityResponseProto.newBuilder();
+            for (String u : uids) {
+                SecurityProto p = store.get(u);
+                if (p != null) b.addSecurityResponse(p);
+            }
+            return b.build();
+        }
+    }
+
+    private static final class RecordingPortfolioFetcher implements LinkResolver.PortfolioFetcher {
+        final Map<String, PortfolioProto> store;
+        int callCount = 0;
+        final List<List<String>> requestedUuids = new ArrayList<>();
+
+        RecordingPortfolioFetcher(Map<String, PortfolioProto> store) { this.store = store; }
+
+        @Override
+        public QueryPortfolioResponseProto getByIds(QueryPortfolioRequestProto request) {
+            callCount++;
+            List<String> uids = new ArrayList<>();
+            for (UUIDProto u : request.getUuIdsList()) uids.add(uuidStrFromProto(u));
+            requestedUuids.add(uids);
+            QueryPortfolioResponseProto.Builder b = QueryPortfolioResponseProto.newBuilder();
+            for (String u : uids) {
+                PortfolioProto p = store.get(u);
+                if (p != null) b.addPortfolioResponse(p);
+            }
+            return b.build();
+        }
+    }
+
+    private static UUIDProto uuidProto(UUID uuid) {
+        ByteBuffer bb = ByteBuffer.allocate(16);
+        bb.putLong(uuid.getMostSignificantBits());
+        bb.putLong(uuid.getLeastSignificantBits());
+        return UUIDProto.newBuilder().setRawUuid(ByteString.copyFrom(bb.array())).build();
+    }
+
+    private static String uuidStrFromProto(UUIDProto p) {
+        ByteBuffer bb = ByteBuffer.wrap(p.getRawUuid().toByteArray());
+        return new UUID(bb.getLong(), bb.getLong()).toString();
+    }
+
+    private static SecurityProto fullSecurity(UUID uuid, String issuer) {
+        return SecurityProto.newBuilder()
+                .setObjectClass("Security")
+                .setVersion("0.0.1")
+                .setUuid(uuidProto(uuid))
+                .setIsLink(false)
+                .setIssuerName(issuer)
+                .setIdentifier(IdentifierProto.newBuilder().setIdentifierValue("TICKER-" + issuer).build())
+                .build();
+    }
+
+    private static PortfolioProto fullPortfolio(UUID uuid, String name) {
+        return PortfolioProto.newBuilder()
+                .setObjectClass("Portfolio")
+                .setVersion("0.0.1")
+                .setUuid(uuidProto(uuid))
+                .setIsLink(false)
+                .setPortfolioName(name)
+                .build();
+    }
+
+    private static SecurityProto linkSecurity(UUID uuid) {
+        return SecurityProto.newBuilder().setUuid(uuidProto(uuid)).setIsLink(true).build();
+    }
+
+    private static SecurityProto linkSecurityWithAsOf(UUID uuid, LocalTimestampProto asOf) {
+        return SecurityProto.newBuilder()
+                .setUuid(uuidProto(uuid))
+                .setIsLink(true)
+                .setAsOf(asOf)
+                .build();
+    }
+
+    private static PriceProto linkPrice(UUID securityUuid) {
+        return PriceProto.newBuilder()
+                .setObjectClass("Price")
+                .setVersion("0.0.1")
+                .setUuid(uuidProto(UUID.randomUUID()))
+                .setSecurity(linkSecurity(securityUuid))
+                .build();
+    }
+
+    private static PriceProto linkPriceWithAsOf(UUID securityUuid, LocalTimestampProto asOf) {
+        return PriceProto.newBuilder()
+                .setObjectClass("Price")
+                .setVersion("0.0.1")
+                .setUuid(uuidProto(UUID.randomUUID()))
+                .setSecurity(linkSecurityWithAsOf(securityUuid, asOf))
+                .build();
+    }
+
+    private static LocalTimestampProto asOfAt(long epochSeconds) {
+        return LocalTimestampProto.newBuilder()
+                .setTimestamp(Timestamp.newBuilder().setSeconds(epochSeconds).setNanos(0).build())
+                .setTimeZone("UTC")
+                .build();
+    }
+
+    // ---------- tests ----------
+
+    @Test
+    void bulkResolveSecuritiesDedupesUuids() {
+        UUID a = UUID.randomUUID(), b = UUID.randomUUID(), c = UUID.randomUUID();
+        Map<String, SecurityProto> store = Map.of(
+                a.toString(), fullSecurity(a, "AAPL"),
+                b.toString(), fullSecurity(b, "MSFT"),
+                c.toString(), fullSecurity(c, "GOOG"));
+        RecordingSecurityFetcher fetcher = new RecordingSecurityFetcher(new HashMap<>(store));
+        LinkResolver resolver = new LinkResolver(fetcher,
+                new RecordingPortfolioFetcher(new HashMap<>()), 1000, 0);
+
+        List<PriceProto> prices = List.of(
+                linkPrice(a), linkPrice(a), linkPrice(b), linkPrice(a), linkPrice(c));
+
+        List<PriceProto> out = resolver.resolveSecuritiesOnPrices(prices);
+
+        assertEquals(1, fetcher.callCount, "5 prices, 3 unique → exactly 1 RPC");
+        assertEquals(3, fetcher.requestedUuids.get(0).size(), "RPC carries 3 deduped UUIDs");
+        Set<String> requested = new HashSet<>(fetcher.requestedUuids.get(0));
+        assertEquals(Set.of(a.toString(), b.toString(), c.toString()), requested);
+
+        for (PriceProto p : out) {
+            assertFalse(p.getSecurity().getIsLink(), "embedded security hydrated");
+            assertNotNull(p.getSecurity().getIssuerName());
+        }
+    }
+
+    @Test
+    void cacheHitSkipsSecondRpc() {
+        UUID uuid = UUID.randomUUID();
+        Map<String, SecurityProto> store = Map.of(uuid.toString(), fullSecurity(uuid, "AAPL"));
+        RecordingSecurityFetcher fetcher = new RecordingSecurityFetcher(new HashMap<>(store));
+        LinkResolver resolver = new LinkResolver(fetcher,
+                new RecordingPortfolioFetcher(new HashMap<>()), 1000, 0);
+
+        SecurityProto s1 = resolver.getSecurity(uuid);
+        SecurityProto s2 = resolver.getSecurity(uuid);
+
+        assertEquals(1, fetcher.callCount);
+        assertEquals("AAPL", s1.getIssuerName());
+        assertEquals("AAPL", s2.getIssuerName());
+    }
+
+    @Test
+    void cacheDisabledReRpcs() {
+        UUID uuid = UUID.randomUUID();
+        Map<String, SecurityProto> store = Map.of(uuid.toString(), fullSecurity(uuid, "AAPL"));
+        RecordingSecurityFetcher fetcher = new RecordingSecurityFetcher(new HashMap<>(store));
+        LinkResolver resolver = new LinkResolver(fetcher,
+                new RecordingPortfolioFetcher(new HashMap<>()), /* cacheSize */ 0, 0);
+
+        resolver.getSecurity(uuid);
+        resolver.getSecurity(uuid);
+
+        assertEquals(2, fetcher.callCount);
+    }
+
+    @Test
+    void nonLinkItemsPassThroughUnchanged() {
+        RecordingSecurityFetcher fetcher = new RecordingSecurityFetcher(new HashMap<>());
+        LinkResolver resolver = new LinkResolver(fetcher,
+                new RecordingPortfolioFetcher(new HashMap<>()), 1000, 0);
+
+        SecurityProto fullSec = fullSecurity(UUID.randomUUID(), "AAPL");
+        PriceProto p = PriceProto.newBuilder()
+                .setObjectClass("Price")
+                .setUuid(uuidProto(UUID.randomUUID()))
+                .setSecurity(fullSec)
+                .build();
+
+        List<PriceProto> out = resolver.resolveSecuritiesOnPrices(List.of(p));
+        assertEquals(0, fetcher.callCount, "no link → no RPC");
+        assertEquals("AAPL", out.get(0).getSecurity().getIssuerName());
+    }
+
+    @Test
+    void itemsMissingSecuritySkippedCleanly() {
+        RecordingSecurityFetcher fetcher = new RecordingSecurityFetcher(new HashMap<>());
+        LinkResolver resolver = new LinkResolver(fetcher,
+                new RecordingPortfolioFetcher(new HashMap<>()), 1000, 0);
+        PriceProto p = PriceProto.newBuilder()
+                .setObjectClass("Price")
+                .setUuid(uuidProto(UUID.randomUUID()))
+                .build();
+        // No security set on this Price.
+        List<PriceProto> out = resolver.resolveSecuritiesOnPrices(List.of(p));
+        assertEquals(0, fetcher.callCount);
+        assertEquals(1, out.size());
+    }
+
+    @Test
+    void crossCallCacheReuse() {
+        UUID a = UUID.randomUUID(), b = UUID.randomUUID();
+        Map<String, SecurityProto> store = Map.of(
+                a.toString(), fullSecurity(a, "AAPL"),
+                b.toString(), fullSecurity(b, "MSFT"));
+        RecordingSecurityFetcher fetcher = new RecordingSecurityFetcher(new HashMap<>(store));
+        LinkResolver resolver = new LinkResolver(fetcher,
+                new RecordingPortfolioFetcher(new HashMap<>()), 1000, 0);
+
+        resolver.resolveSecuritiesOnPrices(List.of(linkPrice(a), linkPrice(b)));
+        assertEquals(1, fetcher.callCount);
+
+        // Both UUIDs cached → 0 additional RPCs.
+        resolver.resolveSecuritiesOnPrices(List.of(linkPrice(a), linkPrice(b)));
+        assertEquals(1, fetcher.callCount);
+    }
+
+    // ---------- as_of-aware ----------
+
+    @Test
+    void linkWithoutAsOfOmitsAsOfOnRequest() {
+        UUID uuid = UUID.randomUUID();
+        Map<String, SecurityProto> store = Map.of(uuid.toString(), fullSecurity(uuid, "AAPL"));
+        RecordingSecurityFetcher fetcher = new RecordingSecurityFetcher(new HashMap<>(store));
+        LinkResolver resolver = new LinkResolver(fetcher,
+                new RecordingPortfolioFetcher(new HashMap<>()), 1000, 0);
+
+        resolver.resolveSecuritiesOnPrices(List.of(linkPrice(uuid)));
+
+        assertEquals(1, fetcher.callCount);
+        assertEquals(-1L, fetcher.requestedAsOfSeconds.get(0), "unset → sentinel -1");
+    }
+
+    @Test
+    void linkWithAsOfCarriesAsOfOnRequest() {
+        UUID uuid = UUID.randomUUID();
+        Map<String, SecurityProto> store = Map.of(uuid.toString(), fullSecurity(uuid, "AAPL"));
+        RecordingSecurityFetcher fetcher = new RecordingSecurityFetcher(new HashMap<>(store));
+        LinkResolver resolver = new LinkResolver(fetcher,
+                new RecordingPortfolioFetcher(new HashMap<>()), 1000, 0);
+
+        LocalTimestampProto t1 = asOfAt(1_700_000_000L);
+        resolver.resolveSecuritiesOnPrices(List.of(linkPriceWithAsOf(uuid, t1)));
+
+        assertEquals(1, fetcher.callCount);
+        assertEquals(1_700_000_000L, fetcher.requestedAsOfSeconds.get(0));
+    }
+
+    @Test
+    void twoAsOfBucketsForSameUuidFireSeparateRpcs() {
+        UUID uuid = UUID.randomUUID();
+        Map<String, SecurityProto> store = Map.of(uuid.toString(), fullSecurity(uuid, "AAPL"));
+        RecordingSecurityFetcher fetcher = new RecordingSecurityFetcher(new HashMap<>(store));
+        LinkResolver resolver = new LinkResolver(fetcher,
+                new RecordingPortfolioFetcher(new HashMap<>()), 1000, 0);
+
+        LocalTimestampProto t1 = asOfAt(1_700_000_000L);
+        LocalTimestampProto t2 = asOfAt(1_800_000_000L);
+
+        resolver.resolveSecuritiesOnPrices(
+                List.of(linkPriceWithAsOf(uuid, t1), linkPriceWithAsOf(uuid, t2)));
+
+        assertEquals(2, fetcher.callCount, "two as_of buckets for same uuid → 2 RPCs");
+        Set<Long> seen = new HashSet<>(fetcher.requestedAsOfSeconds);
+        assertEquals(Set.of(1_700_000_000L, 1_800_000_000L), seen);
+    }
+
+    @Test
+    void sameAsOfForSameUuidDedupsToOneRpc() {
+        UUID uuid = UUID.randomUUID();
+        Map<String, SecurityProto> store = Map.of(uuid.toString(), fullSecurity(uuid, "AAPL"));
+        RecordingSecurityFetcher fetcher = new RecordingSecurityFetcher(new HashMap<>(store));
+        LinkResolver resolver = new LinkResolver(fetcher,
+                new RecordingPortfolioFetcher(new HashMap<>()), 1000, 0);
+
+        LocalTimestampProto t1a = asOfAt(1_700_000_000L);
+        LocalTimestampProto t1b = asOfAt(1_700_000_000L);
+
+        resolver.resolveSecuritiesOnPrices(
+                List.of(linkPriceWithAsOf(uuid, t1a), linkPriceWithAsOf(uuid, t1b)));
+
+        assertEquals(1, fetcher.callCount);
+        assertEquals(1, fetcher.requestedUuids.get(0).size());
+    }
+
+    @Test
+    void cacheKeyIncludesAsOf() {
+        UUID uuid = UUID.randomUUID();
+        Map<String, SecurityProto> store = Map.of(uuid.toString(), fullSecurity(uuid, "AAPL"));
+        RecordingSecurityFetcher fetcher = new RecordingSecurityFetcher(new HashMap<>(store));
+        LinkResolver resolver = new LinkResolver(fetcher,
+                new RecordingPortfolioFetcher(new HashMap<>()), 1000, 0);
+
+        LocalTimestampProto t1 = asOfAt(1_700_000_000L);
+
+        resolver.getSecurity(uuid);
+        assertEquals(1, fetcher.callCount);
+        assertEquals(-1L, fetcher.requestedAsOfSeconds.get(0));
+
+        resolver.getSecurity(uuid, t1);
+        assertEquals(2, fetcher.callCount, "(uuid, t1) is a different cache key from (uuid, latest)");
+        assertEquals(1_700_000_000L, fetcher.requestedAsOfSeconds.get(1));
+
+        resolver.getSecurity(uuid, asOfAt(1_700_000_000L));
+        assertEquals(2, fetcher.callCount, "cache hit on (uuid, t1)");
+    }
+
+    // ---------- transaction (security + portfolio) ----------
+
+    @Test
+    void resolveBothSecurityAndPortfolioOnTransactions() {
+        UUID secA = UUID.randomUUID(), secB = UUID.randomUUID();
+        UUID portX = UUID.randomUUID(), portY = UUID.randomUUID();
+
+        Map<String, SecurityProto> secStore = Map.of(
+                secA.toString(), fullSecurity(secA, "AAPL"),
+                secB.toString(), fullSecurity(secB, "MSFT"));
+        Map<String, PortfolioProto> portStore = Map.of(
+                portX.toString(), fullPortfolio(portX, "Strategy X"),
+                portY.toString(), fullPortfolio(portY, "Strategy Y"));
+
+        RecordingSecurityFetcher secFetcher = new RecordingSecurityFetcher(new HashMap<>(secStore));
+        RecordingPortfolioFetcher portFetcher = new RecordingPortfolioFetcher(new HashMap<>(portStore));
+        LinkResolver resolver = new LinkResolver(secFetcher, portFetcher, 1000, 0);
+
+        TransactionProto t1 = TransactionProto.newBuilder()
+                .setObjectClass("Transaction")
+                .setUuid(uuidProto(UUID.randomUUID()))
+                .setSecurity(linkSecurity(secA))
+                .setPortfolio(PortfolioProto.newBuilder().setUuid(uuidProto(portX)).setIsLink(true).build())
+                .build();
+        TransactionProto t2 = TransactionProto.newBuilder()
+                .setObjectClass("Transaction")
+                .setUuid(uuidProto(UUID.randomUUID()))
+                .setSecurity(linkSecurity(secB))
+                .setPortfolio(PortfolioProto.newBuilder().setUuid(uuidProto(portY)).setIsLink(true).build())
+                .build();
+        TransactionProto t3 = TransactionProto.newBuilder()
+                .setObjectClass("Transaction")
+                .setUuid(uuidProto(UUID.randomUUID()))
+                .setSecurity(linkSecurity(secA))
+                .setPortfolio(PortfolioProto.newBuilder().setUuid(uuidProto(portX)).setIsLink(true).build())
+                .build();
+
+        List<TransactionProto> hydrated = resolver.resolveSecuritiesOnTransactions(List.of(t1, t2, t3));
+        hydrated = resolver.resolvePortfoliosOnTransactions(hydrated);
+
+        assertEquals(1, secFetcher.callCount, "security side: 1 batched RPC for 2 unique UUIDs");
+        assertEquals(1, portFetcher.callCount, "portfolio side: 1 batched RPC for 2 unique UUIDs");
+
+        for (TransactionProto t : hydrated) {
+            assertFalse(t.getSecurity().getIsLink());
+            assertFalse(t.getPortfolio().getIsLink());
+            assertTrue(Set.of("AAPL", "MSFT").contains(t.getSecurity().getIssuerName()));
+            assertTrue(Set.of("Strategy X", "Strategy Y").contains(t.getPortfolio().getPortfolioName()));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Java parity for the JS / Python LinkResolver shipped in #181 / #183. Same semantics: `GetByIds`-backed batched lookups, `(uuid, as_of)` cache key, per-bucket batching, in-flight de-dup of concurrent same-key requests.

Discussion + spec: FinTekkers/second-brain#196 + the technical-details addendum in [`is_link_pattern.md`](https://github.com/FinTekkers/ledger-models/blob/main/docs/adr/is_link_pattern.md).

## Surface

```
src/main/java/common/util/LinkResolver.java                  (new)

  new LinkResolver(url, port, isHttp)        production ctor
  new LinkResolver(secFetcher, portFetcher,  test ctor
                   cacheSize, ttlMillis)

  .getSecurity(uuid)           / .getSecurity(uuid, asOf)
  .getPortfolio(uuid)          / .getPortfolio(uuid, asOf)
  .resolveSecuritiesOnPrices(prices)          → new List<PriceProto>
  .resolveSecuritiesOnTransactions(txns)      → new List<TransactionProto>
  .resolvePortfoliosOnTransactions(txns)      → new List<TransactionProto>
  .clearCache()                                test helper

  SecurityFetcher / PortfolioFetcher          functional-interface
                                              test injection seams
```

## Java-specific differences from JS / Python (intentional)

- **Java protobufs are immutable**, so `resolveX` returns a NEW `List` with hydrated copies via `toBuilder().setSecurity(resolved).build()`. Items whose embedded sub-message is already full, or which have no sub-message, pass through unchanged (same instance, no rebuild cost).
- **LRU** is a `synchronized LinkedHashMap` with access-order + `removeEldestEntry` — the standard Java idiom. No third-party dep.
- **In-flight dedup** uses `ConcurrentHashMap<String, CompletableFuture<...>>`; first caller does the fetch, others `.join()` the same future.
- **Per-type bulk methods** (`resolveSecuritiesOnPrices`, `...OnTransactions`, ...) instead of a generic `<T>`. Java functional refs for proto builders are verbose; explicit overloads are clearer at call sites and there are only 3 embedding patterns in the model today.

## Out of scope (separate ticket)

- **`PriceService.java` / `SecurityService.java` / `TransactionService.java` handwritten wrappers.** Java has only `PortfolioService` / `ValuationService` today. Once those land, they can compose `LinkResolver` with `searchWithSecurities` / `searchWithSecurityAndPortfolio` convenience methods (matching JS / Python).
- **`isLink()` helpers on Java domain wrappers.** Unlike JS / Python, Java's `Security`/`Price`/`Portfolio` classes are not direct proto wrappers — they're parsed Java objects. Consumers reading proto state today already call `securityProto.getIsLink()` directly. Adding helpers to the Java domain wrappers can come along with the new service wrappers.

## Test plan

- [x] **12 new tests** in `src/test/java/common/util/LinkResolverTest.java` (JUnit 5), mocking the `SecurityFetcher` / `PortfolioFetcher` seams:
  - bulk dedupes UUIDs (5 prices, 3 unique → 1 RPC, 3 UUIDs)
  - cache hit skips 2nd RPC for same (uuid, as_of)
  - `cacheSize=0` disables caching
  - non-link items pass through (no RPC, no rebuild)
  - items missing security skipped cleanly
  - cross-call cache reuse
  - **as_of-aware:** link without `as_of` → request omits `as_of`
  - **as_of-aware:** link with `as_of` → request carries that `as_of`
  - **as_of-aware:** two `as_of` buckets for same UUID → 2 separate RPCs
  - **as_of-aware:** same `as_of` for same UUID → 1 RPC (bucket dedup)
  - **as_of-aware:** cache key includes `as_of` (latest vs t1 don't alias)
  - resolve both security + portfolio on transactions end-to-end (1 batched RPC per entity type)
- [x] `./gradlew test` — full Java suite green (12 new + existing).
- [ ] CI compile.sh gate covers all 4 languages — confirms no JS/Python/Rust regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)