### PR TITLE
fix: add 5 missing Measure enum constants for bond analytics (#219)

### DIFF
--- a/ledger-models-java/src/main/java/common/models/postion/Measure.java
+++ b/ledger-models-java/src/main/java/common/models/postion/Measure.java
@@ -45,7 +45,27 @@ public enum Measure {
             "Formula: MarketValue - (UnadjustedCostBasis / 100 * DirectedQuantity). Units: Dollars."),
 
     PROFIT_LOSS_PERCENT("The profit or loss as a percentage of the original cost basis. " +
-            "Formula: ProfitLoss / (UnadjustedCostBasis / 100 * DirectedQuantity). Units: Decimal (0-1 scale).");
+            "Formula: ProfitLoss / (UnadjustedCostBasis / 100 * DirectedQuantity). Units: Decimal (0-1 scale)."),
+
+    ACCRUED_INTEREST("Bond coupon interest earned but not yet paid since the last coupon date. " +
+            "Computed by valuation-service from coupon_rate, coupon_frequency, and the day-count " +
+            "fraction between the last coupon and the as-of date. Bond-specific; null for non-bonds."),
+
+    DIRTY_PRICE("Bond invoice price including accrued interest, expressed as % of par. " +
+            "Computed by valuation-service as DirtyPrice = market_value / directed_quantity * 100. " +
+            "Bond-specific; null for non-bonds."),
+
+    CLEAN_PRICE("Bond quoted price excluding accrued interest, expressed as % of par. " +
+            "Computed by valuation-service as CleanPrice = DirtyPrice − (AccruedInterest / DirectedQuantity * 100). " +
+            "Bond-specific; null for non-bonds."),
+
+    CONVEXITY("Second-order sensitivity of bond price to yield changes (curvature of the price-yield curve). " +
+            "Computed by valuation-service as Σ[t(t+1) × PV_t] / (P_dollar × n² × (1+r)²). " +
+            "Bond-specific; null for non-bonds."),
+
+    MODIFIED_DURATION("First-order sensitivity of bond price to yield changes, expressed in years. " +
+            "Computed by valuation-service as MacaulayDuration / (1 + y/n). " +
+            "Bond-specific; null for non-bonds.");
 
     static {
         Set<String> measureNames = Arrays.stream(Measure.values())


### PR DESCRIPTION
## Summary

Adds the 5 missing constants to `common.models.postion.Measure`:

- `ACCRUED_INTEREST`
- `DIRTY_PRICE`
- `CLEAN_PRICE`
- `CONVEXITY`
- `MODIFIED_DURATION`

Pairs with [ledger-service PR for #219](https://github.com/FinTekkers/ledger-service) which wires them up in `PositionAggregator`. Pure Java enum addition — **no proto change, no regen**.

## Why

`fintekkers.models.position.MeasureProto` already exposes these values, and `valuation-service` already implements them in `src/calculators/bond_calculator/`. But `PositionAPIGRPCImpl.search` calls `Measure.valueOf(measureProto.name())` and the Java domain enum was missing these — so any request including one of them errored with `UNIMPLEMENTED: No enum constant common.models.postion.Measure.<X>`, **500-ing the entire stream** and blocking every other measure in the same request.

The static-init block on `Measure` (`if !measureNames.contains(proto.name())`) was already warning about this gap on JVM startup.

## Test plan

- [x] `./gradlew :ledger-models-java:build -x test` passes
- [x] `Measure.class` decompile shows all 15 constants
- [ ] CI compile.sh gate (will run on PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)