### PR TITLE
refactor: bond_security uses SecurityType wrapper internally (#195 follow-up)

### DIFF
--- a/ledger-models-rust/fintekkers/wrappers/models/bond_security.rs
+++ b/ledger-models-rust/fintekkers/wrappers/models/bond_security.rs
@@ -4,6 +4,7 @@ use rust_decimal::Decimal;
 use crate::fintekkers::models::security::security_proto::ProductDetails;
 use crate::fintekkers::models::security::{SecurityProto, SecurityTypeProto};
 use crate::fintekkers::models::util::LocalDateProto;
+use crate::fintekkers::wrappers::models::security_type::SecurityType;
 use crate::fintekkers::wrappers::models::utils::errors::Error;
 
 pub struct BondSecurity {
@@ -12,12 +13,16 @@ pub struct BondSecurity {
 
 impl BondSecurity {
     pub fn from_proto(proto: SecurityProto) -> Result<Self, Error> {
-        let st = SecurityTypeProto::from_i32(proto.security_type)
+        // Resolve the proto's security_type i32 → SecurityTypeProto →
+        // SecurityType wrapper. Bond-flavored security types (Bond, Tips,
+        // Frn) all collapse to SecurityType::Bond/Tips/Frn here, which is
+        // the membership predicate this wrapper cares about.
+        let st_proto = SecurityTypeProto::from_i32(proto.security_type)
             .unwrap_or(SecurityTypeProto::UnknownSecurityType);
-        match st {
-            SecurityTypeProto::BondSecurity
-            | SecurityTypeProto::Tips
-            | SecurityTypeProto::Frn => Ok(BondSecurity { proto }),
+        match SecurityType::from_proto(st_proto) {
+            SecurityType::Bond | SecurityType::Tips | SecurityType::Frn => {
+                Ok(BondSecurity { proto })
+            }
             _ => Err(Error::NotABondSecurity),
         }
     }


### PR DESCRIPTION
## Summary

Pure structural refactor of `bond_security.rs::from_proto` — uses the `SecurityType` wrapper enum landed in PR #195 instead of the inline `SecurityTypeProto::{BondSecurity,Tips,Frn}` match.

Called out as out-of-scope in PR #195's body; doing it now that v0.1.139 ships the wrapper.

## Diff

**Before:**

```rust
match SecurityTypeProto::from_i32(proto.security_type)... {
    SecurityTypeProto::BondSecurity
    | SecurityTypeProto::Tips
    | SecurityTypeProto::Frn => Ok(...),
    _ => Err(...),
}
```

**After:**

```rust
match SecurityType::from_proto(st_proto) {
    SecurityType::Bond | SecurityType::Tips | SecurityType::Frn => Ok(...),
    _ => Err(...),
}
```

10 insertions / 5 deletions.

## Why

Reduces inline `SecurityTypeProto` matching duplication that PR #195's wrapper was designed to absorb. `bond_security.rs` was the in-tree consumer I called out as the next migration target; this PR makes ledger-models internally consistent with what we're now exposing to external Rust consumers.

## No behavior change

`SecurityType::from_proto` is total, and the bond-membership predicate (`Bond | Tips | Frn`) is preserved alongside the `_ => Err(NotABondSecurity)` default. Any input that was bond-valid before is bond-valid now; any input that errored before still errors now.

## Test plan

- [x] `cargo build` — clean (one pre-existing `position.rs` dead_code warning, unrelated to this PR).
- [x] `cargo test` — **106 passed; 0 failed** (same as PR #195 baseline).
- [x] `bond_security` tests specifically: **11 passed; 0 failed**.
- [x] Wrapper-only — no proto change, no regen, no version bump needed (the `SecurityType` wrapper already shipped in v0.1.139).

🤖 Generated with [Claude Code](https://claude.com/claude-code)