### PR TITLE
fix: route T_BILL + STRIPS_SECURITY through bond-fields path in SecuritySerializer + BondSerializer (#252)

### DIFF
--- a/ledger-models-java/src/main/java/protos/serializers/security/BondSerializer.java
+++ b/ledger-models-java/src/main/java/protos/serializers/security/BondSerializer.java
@@ -127,6 +127,13 @@ public class BondSerializer {
 
         switch (securityType) {
             case BOND_SECURITY:
+            case T_BILL:
+            case STRIPS_SECURITY:
+                // T_BILL and STRIPS_SECURITY are zero-coupon bonds with the same
+                // shape as a vanilla bond (face_value, issue_date, maturity_date,
+                // dated_date, coupon_rate=0). No specialized subclass yet — when
+                // T-bill-specific behavior emerges (e.g. discount-yield convention),
+                // we'll add a TBillSecurity subclass and split the cases.
                 return new BondSecurity(id, issuer, asOf, settlementCurrency);
             case TIPS:
                 return new TIPSBond(id, issuer, asOf, settlementCurrency);

--- a/ledger-models-java/src/main/java/protos/serializers/security/SecuritySerializer.java
+++ b/ledger-models-java/src/main/java/protos/serializers/security/SecuritySerializer.java
@@ -144,6 +144,8 @@ public class SecuritySerializer implements IRawDataModelObjectSerializer<Securit
             case BOND_SECURITY:
             case TIPS:
             case FRN:
+            case T_BILL:
+            case STRIPS_SECURITY:
                 validateBondDates(proto);
                 security = new BondSerializer().deserializeBondSecurity(proto, id, asOf, issuer, settlementCurrency);
                 break;

--- a/ledger-models-java/src/test/java/protos/serializers/security/TBillStripsRoundTripTest.java
+++ b/ledger-models-java/src/test/java/protos/serializers/security/TBillStripsRoundTripTest.java
@@ -1,0 +1,94 @@
+package protos.serializers.security;
+
+import common.models.security.BondSecurity;
+import common.models.security.Security;
+import fintekkers.models.security.CouponFrequencyProto;
+import fintekkers.models.security.CouponTypeProto;
+import fintekkers.models.security.SecurityProto;
+import fintekkers.models.security.SecurityQuantityTypeProto;
+import fintekkers.models.security.SecurityTypeProto;
+import fintekkers.models.util.DecimalValue.DecimalValueProto;
+import fintekkers.models.util.LocalDate.LocalDateProto;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Regression test for #252 — T_BILL and STRIPS_SECURITY were added in v0.1.141
+ * but were not wired into SecuritySerializer.deserialize / BondSerializer.initiatlize.
+ * They fell through to the default branch and produced a plain Security with all
+ * bond fields dropped on round-trip.
+ *
+ * This test exercises the fix: T_BILL and STRIPS_SECURITY proto → BondSecurity
+ * with face_value, issue_date, maturity_date, dated_date, coupon_rate populated.
+ */
+class TBillStripsRoundTripTest {
+
+    private static DecimalValueProto decimal(String v) {
+        return DecimalValueProto.newBuilder().setArbitraryPrecisionValue(v).build();
+    }
+
+    private static LocalDateProto date(LocalDate d) {
+        return LocalDateProto.newBuilder()
+                .setYear(d.getYear()).setMonth(d.getMonthValue()).setDay(d.getDayOfMonth())
+                .build();
+    }
+
+    private static SecurityProto.Builder zeroCouponBondShape(SecurityTypeProto type) {
+        LocalDate issue = LocalDate.of(2025, 1, 15);
+        LocalDate maturity = LocalDate.of(2025, 7, 15);
+        return SecurityProto.newBuilder()
+                .setObjectClass("Security")
+                .setVersion("0.0.1")
+                .setSecurityType(type)
+                .setAssetClass("Fixed Income")
+                .setIssuerName("US Treasury")
+                .setQuantityType(SecurityQuantityTypeProto.ORIGINAL_FACE_VALUE)
+                .setCouponRate(decimal("0"))
+                .setCouponType(CouponTypeProto.ZERO)
+                .setCouponFrequency(CouponFrequencyProto.NO_COUPON)
+                .setFaceValue(decimal("1000"))
+                .setIssueDate(date(issue))
+                .setDatedDate(date(issue))
+                .setMaturityDate(date(maturity));
+    }
+
+    @Test
+    public void tBillBondFieldsSurviveDeserialize() {
+        SecurityProto proto = zeroCouponBondShape(SecurityTypeProto.T_BILL).build();
+
+        Security security = SecuritySerializer.getInstance().deserialize(proto);
+
+        assertInstanceOf(BondSecurity.class, security,
+                "T_BILL must deserialize to BondSecurity, not the default plain Security");
+        BondSecurity bond = (BondSecurity) security;
+        assertNotNull(bond.getFaceValue());
+        assertEquals(0, bond.getFaceValue().compareTo(BigDecimal.valueOf(1000)));
+        assertEquals(LocalDate.of(2025, 1, 15), bond.getIssueDate());
+        assertEquals(LocalDate.of(2025, 1, 15), bond.getDatedDate());
+        assertEquals(LocalDate.of(2025, 7, 15), bond.getMaturityDate());
+        assertNotNull(bond.getCouponRate());
+        assertEquals(0, bond.getCouponRate().compareTo(BigDecimal.ZERO));
+    }
+
+    @Test
+    public void stripsSecurityBondFieldsSurviveDeserialize() {
+        SecurityProto proto = zeroCouponBondShape(SecurityTypeProto.STRIPS_SECURITY).build();
+
+        Security security = SecuritySerializer.getInstance().deserialize(proto);
+
+        assertInstanceOf(BondSecurity.class, security,
+                "STRIPS_SECURITY must deserialize to BondSecurity, not the default plain Security");
+        BondSecurity bond = (BondSecurity) security;
+        assertNotNull(bond.getFaceValue());
+        assertEquals(0, bond.getFaceValue().compareTo(BigDecimal.valueOf(1000)));
+        assertEquals(LocalDate.of(2025, 1, 15), bond.getIssueDate());
+        assertEquals(LocalDate.of(2025, 1, 15), bond.getDatedDate());
+        assertEquals(LocalDate.of(2025, 7, 15), bond.getMaturityDate());
+    }
+}


### PR DESCRIPTION
## Summary

T_BILL (added in v0.1.141, #246) and STRIPS_SECURITY (same release) were not wired into:

- `SecuritySerializer.deserialize` — fell through the `default:` branch → returned a plain `Security` with all bond fields silently dropped.
- `BondSerializer.initiatlize` — threw `RuntimeException("The security type is not supported")` if anything ever did route there.

Net effect: a T_BILL or STRIPS proto with `face_value`, `issue_date`, `dated_date`, `maturity_date`, `coupon_rate=0` populated round-tripped to a plain Security with all of those fields gone.

## User direction (verbatim)

> For #35, let's do this too: The clean ledger-models fix. Two-line switch addition in SecuritySerializer.deserialize + BondSerializer.initiatlize. Filed as a follow-up concern in the helper class docstring; the helper can be deleted once those land.

## Fix

Two switches, two new case-fall-throughs:

`SecuritySerializer.deserialize`:
```java
case BOND_SECURITY:
case TIPS:
case FRN:
case T_BILL:           // ← new
case STRIPS_SECURITY:  // ← new
    validateBondDates(proto);
    security = new BondSerializer().deserializeBondSecurity(...);
    break;
```

`BondSerializer.initiatlize`:
```java
case BOND_SECURITY:
case T_BILL:           // ← new
case STRIPS_SECURITY:  // ← new
    return new BondSecurity(id, issuer, asOf, settlementCurrency);
```

T_BILL and STRIPS share the same field shape as a vanilla bond (face_value, issue_date, maturity_date, dated_date, coupon_rate=0) — zero-coupon. No specialized subclass yet; when discount-yield convention or strip-specific behavior emerges, we'll add `TBillSecurity` / `StripsSecurity` subclasses and split the cases. Comment to that effect in BondSerializer.

## Test

`TBillStripsRoundTripTest` (new) — builds a T_BILL and a STRIPS_SECURITY `SecurityProto` with all bond-shaped fields populated, runs `SecuritySerializer.deserialize`, and asserts:

1. The result is a `BondSecurity` (not the default plain `Security`).
2. `face_value`, `issue_date`, `dated_date`, `maturity_date`, `coupon_rate` are all preserved.

Both tests pass. Full Java suite green (`./gradlew test`).

## Out of scope (separate ledger-service PR after this ships)

The workaround helper [`SecurityDeserializerFallback`](https://github.com/FinTekkers/ledger-service/pull/35) in ledger-service PR #35 — which rewrites `security_type` to `BOND_SECURITY` before calling deserialize — becomes obsolete after this lands and a release ships. Follow-up: delete the helper, both call sites revert to direct `SecuritySerializer.deserialize`.

## Scope

- Java only — no proto change, no other-language change, no breaking change.
- Strictly additive in switch coverage (no removal, no reordering).

🤖 Generated with [Claude Code](https://claude.com/claude-code)