### PR TITLE
fix: preserve security_type marker on BondSecurity proto round-trip (#201 follow-up)

### DIFF
--- a/ledger-models-java/src/main/java/common/models/security/BondSecurity.java
+++ b/ledger-models-java/src/main/java/common/models/security/BondSecurity.java
@@ -2,6 +2,7 @@ package common.models.security;
 
 import common.models.JSONFieldNames;
 import common.models.postion.Field;
+import fintekkers.models.security.SecurityProto;
 import fintekkers.models.security.SecurityTypeProto;
 
 import java.math.BigDecimal;
@@ -142,6 +143,20 @@ public class BondSecurity extends Security {
 
     @Override
     public SecurityTypeProto getSecurityType() {
+        // BondSecurity is the catch-all wrapper for bond-shape proto types
+        // (BOND_SECURITY, T_BILL, STRIPS_SECURITY, plus any future addition
+        // that fits the same field shape). Read the type from the source
+        // proto when present so the marker survives a deserialize → re-
+        // serialize round-trip. Specialized subclasses (TIPSBond,
+        // FloatingRateNote) override this with their own hardcoded type
+        // and are unaffected. Mirrors the proto-first pattern that
+        // Security.getAssetClass uses.
+        SecurityProto src = getSecurityProto();
+        if (src != null) {
+            return src.getSecurityType();
+        }
+        // Legacy fallback: BondSecurity constructed via the (id, issuer,
+        // asOf, settlementCurrency) constructor without a stashed proto.
         return SecurityTypeProto.BOND_SECURITY;
     }
 

--- a/ledger-models-java/src/test/java/protos/serializers/security/TBillStripsRoundTripTest.java
+++ b/ledger-models-java/src/test/java/protos/serializers/security/TBillStripsRoundTripTest.java
@@ -19,13 +19,21 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
- * Regression test for #252 — T_BILL and STRIPS_SECURITY were added in v0.1.141
- * but were not wired into SecuritySerializer.deserialize / BondSerializer.initiatlize.
- * They fell through to the default branch and produced a plain Security with all
- * bond fields dropped on round-trip.
+ * Regression test for the T_BILL / STRIPS_SECURITY round-trip path.
  *
- * This test exercises the fix: T_BILL and STRIPS_SECURITY proto → BondSecurity
- * with face_value, issue_date, maturity_date, dated_date, coupon_rate populated.
+ * Two layered concerns:
+ *
+ *   1. (#252 / PR #201) Bond-shaped fields (face_value, issue_date,
+ *      dated_date, maturity_date, coupon_rate) must survive deserialize.
+ *      Fix: route T_BILL + STRIPS_SECURITY through the bond-fields path
+ *      in SecuritySerializer.deserialize / BondSerializer.initiatlize.
+ *
+ *   2. (#201 follow-up / PR #202) The security_type marker itself must
+ *      survive deserialize → re-serialize. Fix: BondSecurity.getSecurityType
+ *      now reads from the source proto when present, falling back to
+ *      BOND_SECURITY only for legacy non-proto-constructed bonds. This is
+ *      type-agnostic — adding a future bond-shape security_type to the
+ *      proto won't require touching BondSecurity again.
  */
 class TBillStripsRoundTripTest {
 
@@ -36,6 +44,18 @@ class TBillStripsRoundTripTest {
     private static LocalDateProto date(LocalDate d) {
         return LocalDateProto.newBuilder()
                 .setYear(d.getYear()).setMonth(d.getMonthValue()).setDay(d.getDayOfMonth())
+                .build();
+    }
+
+    private static SecurityProto usdCashProto() {
+        return SecurityProto.newBuilder()
+                .setObjectClass("Security")
+                .setVersion("0.0.1")
+                .setSecurityType(SecurityTypeProto.CASH_SECURITY)
+                .setAssetClass("Cash")
+                .setIssuerName("Federal Reserve")
+                .setQuantityType(SecurityQuantityTypeProto.UNITS)
+                .setCashId("USD")
                 .build();
     }
 
@@ -55,7 +75,8 @@ class TBillStripsRoundTripTest {
                 .setFaceValue(decimal("1000"))
                 .setIssueDate(date(issue))
                 .setDatedDate(date(issue))
-                .setMaturityDate(date(maturity));
+                .setMaturityDate(date(maturity))
+                .setSettlementCurrency(usdCashProto());
     }
 
     @Test
@@ -90,5 +111,79 @@ class TBillStripsRoundTripTest {
         assertEquals(LocalDate.of(2025, 1, 15), bond.getIssueDate());
         assertEquals(LocalDate.of(2025, 1, 15), bond.getDatedDate());
         assertEquals(LocalDate.of(2025, 7, 15), bond.getMaturityDate());
+    }
+
+    /**
+     * Regression: BondSecurity.getSecurityType() used to hardcode BOND_SECURITY,
+     * so a T_BILL proto deserialized → BondSecurity → re-serialized came out as
+     * BOND_SECURITY. Empirically observed by data-sourcing-dev: 1,384 T_BILL
+     * rows → 0 after a v0.1.143 ledger-service rebuild (rows mutated to
+     * BOND_SECURITY in the read/hydrate path).
+     *
+     * Fix: BondSecurity.getSecurityType() now consults the source proto when
+     * the type is T_BILL or STRIPS_SECURITY, falls back to BOND_SECURITY
+     * otherwise. This test fails on main without the fix.
+     */
+    @Test
+    public void tBillTypeMarkerSurvivesDeserializeReserialize() {
+        SecurityProto original = zeroCouponBondShape(SecurityTypeProto.T_BILL).build();
+
+        SecuritySerializer ser = SecuritySerializer.getInstance();
+        Security deserialized = ser.deserialize(original);
+        SecurityProto reSerialized = ser.serialize(deserialized);
+
+        assertEquals(SecurityTypeProto.T_BILL, reSerialized.getSecurityType(),
+                "T_BILL marker must survive round-trip; on the buggy path it reverts to BOND_SECURITY");
+    }
+
+    @Test
+    public void stripsSecurityTypeMarkerSurvivesDeserializeReserialize() {
+        SecurityProto original = zeroCouponBondShape(SecurityTypeProto.STRIPS_SECURITY).build();
+
+        SecuritySerializer ser = SecuritySerializer.getInstance();
+        Security deserialized = ser.deserialize(original);
+        SecurityProto reSerialized = ser.serialize(deserialized);
+
+        assertEquals(SecurityTypeProto.STRIPS_SECURITY, reSerialized.getSecurityType(),
+                "STRIPS_SECURITY marker must survive round-trip; on the buggy path it reverts to BOND_SECURITY");
+    }
+
+    /**
+     * Vanilla BOND_SECURITY round-trip: marker preserved (the generic
+     * proto-read covers it the same as any other bond-shape type).
+     */
+    @Test
+    public void vanillaBondTypeMarkerStillBondSecurity() {
+        SecurityProto original = zeroCouponBondShape(SecurityTypeProto.BOND_SECURITY).build();
+
+        SecuritySerializer ser = SecuritySerializer.getInstance();
+        Security deserialized = ser.deserialize(original);
+        SecurityProto reSerialized = ser.serialize(deserialized);
+
+        assertEquals(SecurityTypeProto.BOND_SECURITY, reSerialized.getSecurityType());
+    }
+
+    /**
+     * Locks in the legacy fallback path: a BondSecurity constructed via the
+     * (id, issuer, asOf, settlementCurrency) constructor — without a stashed
+     * SecurityProto — still reports BOND_SECURITY. Then attaching a proto
+     * with a different type via setSecurityProto flips the reported type.
+     * This pins the proto-first / legacy-fallback contract independently of
+     * the deserialize path.
+     */
+    @Test
+    public void getSecurityTypeFallsBackToBondSecurityWhenProtoUnset() {
+        BondSecurity bond = new BondSecurity(
+                java.util.UUID.randomUUID(),
+                "Issuer",
+                java.time.ZonedDateTime.now(),
+                common.models.security.CashSecurity.USD);
+
+        assertEquals(SecurityTypeProto.BOND_SECURITY, bond.getSecurityType(),
+                "No source proto → legacy fallback to BOND_SECURITY");
+
+        bond.setSecurityProto(zeroCouponBondShape(SecurityTypeProto.T_BILL).build());
+        assertEquals(SecurityTypeProto.T_BILL, bond.getSecurityType(),
+                "Source proto present → reports the proto's type (generic, not special-cased)");
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to #201. PR #201 routed `T_BILL` and `STRIPS_SECURITY` through `BondSerializer` so the bond-shaped fields (`face_value`, `issue_date`, `dated_date`, `maturity_date`, `coupon_rate`) survive deserialize. **Bond fields recover correctly** — but the **type marker did not**.

## Mechanism

`BondSerializer.initiatlize` returns a plain `BondSecurity` for both `T_BILL` and `STRIPS_SECURITY` — no specialized subclass exists, since they share the vanilla bond field shape. The plain `BondSecurity.getSecurityType()` was:

```java
@Override
public SecurityTypeProto getSecurityType() {
    return SecurityTypeProto.BOND_SECURITY;
}
```

Hardcoded, ignored `_sourceProto`. On re-serialize, `SecuritySerializer.serialize` sets `security_type` from `security.getSecurityType()` → emitted as `BOND_SECURITY`, losing the original type marker.

`TIPS` and `FRN` are unaffected — they have their own subclass overrides (`TIPSBond`, `FloatingRateNote`) that hardcode the correct values.

## Empirical evidence

data-sourcing-dev's probe:

| Snapshot | T_BILL rows | BOND_SECURITY rows |
| --- | --- | --- |
| Pre-rebuild | 1,384 | (baseline) |
| Post-v0.1.143 rebuild | **0** | **+6,099** (1,384 reverted) |

No new `--live` ingestion ran in that window. The transition happened entirely through the v0.1.143 ledger-service rebuild — i.e. the read/hydrate path mutated rows to `BOND_SECURITY` in memory and on re-serialize.

## Review feedback addressed

User feedback on the first revision of this PR:

> For 202, no tactical unblock. Fix it properly.

The first revision special-cased the fix:

```java
if (srcType == SecurityTypeProto.T_BILL || srcType == SecurityTypeProto.STRIPS_SECURITY) {
    return srcType;
}
```

That's a code smell. The proper fix is generic — read from the proto for **all** types, not a name-pinned subset.

## Fix (generic)

```java
@Override
public SecurityTypeProto getSecurityType() {
    SecurityProto src = getSecurityProto();
    if (src != null) {
        return src.getSecurityType();
    }
    // Legacy fallback: BondSecurity constructed via the
    // (id, issuer, asOf, settlementCurrency) constructor without a
    // stashed proto.
    return SecurityTypeProto.BOND_SECURITY;
}
```

Properties:
- **Type-agnostic.** Covers `BOND_SECURITY`, `T_BILL`, `STRIPS_SECURITY`, and any future bond-shape addition (e.g. a hypothetical `BOND_NOTE_SECURITY` someone might add later) without further changes to `BondSecurity`.
- **Mirrors the existing pattern.** `Security.getAssetClass` already does proto-first / fallback for proto-derived fields.
- **Specialized subclasses unaffected.** `TIPSBond` and `FloatingRateNote` keep their own hardcoded overrides; the generic check only applies when `BondSecurity` itself is the wrapper.
- **Legacy fallback preserved.** `new BondSecurity(id, issuer, asOf, settlementCurrency)` without `setSecurityProto` still reports `BOND_SECURITY`, so `BondSerializerTest.testBond` (which constructs a bond programmatically) still passes.

## Test

`TBillStripsRoundTripTest` gains four checks:

- **`tBillTypeMarkerSurvivesDeserializeReserialize`** — builds a T_BILL proto, deserialize → re-serialize, asserts `security_type` still `T_BILL`. Failed on `main` without the fix: `expected: <T_BILL> but was: <BOND_SECURITY>`.
- **`stripsSecurityTypeMarkerSurvivesDeserializeReserialize`** — same shape for STRIPS_SECURITY.
- **`vanillaBondTypeMarkerStillBondSecurity`** — a `BOND_SECURITY` proto round-trips to `BOND_SECURITY`. The generic fix covers this the same as any other bond-shape type.
- **`getSecurityTypeFallsBackToBondSecurityWhenProtoUnset`** *(new)* — locks in the legacy fallback contract: a `BondSecurity` built via the `(id, issuer, asOf, settlementCurrency)` constructor with no stashed proto reports `BOND_SECURITY`. After `setSecurityProto` with a T_BILL proto, reports `T_BILL`. Pins the proto-first / legacy-fallback contract independently of the deserialize path.

Verified the test fails on the original buggy code and passes with the fix. Full `./gradlew test` suite green.

## Scope

- Java only — one source file, one test file.
- No proto change.
- No change to vanilla `BondSecurity` / `TIPS` / `FRN` round-trip behavior.

## Post-merge

Per PM:
1. Run `release.sh` for v0.1.144.
2. ledger-service rebuilds against v0.1.144.
3. data-sourcing-dev re-probes; T_BILL count restored to 1,384.

🤖 Generated with [Claude Code](https://claude.com/claude-code)