### PR TITLE
fix(python): bundle hierarchy.json in wheel — fixes consumer vendoring antipattern (v0.2.2)

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -44,6 +44,19 @@ jobs:
           pwd
 
           BUILD_VERSION=${{ env.release_version }} python3 setup.py sdist bdist_wheel
+
+          # v0.2.2 — verify the wheel actually bundles hierarchy.json
+          # before twine upload. v0.2.1 shipped a broken wheel
+          # (MANIFEST.in didn't list *.json) and consumers had to vendor
+          # the file. Fail loudly on regression rather than re-shipping
+          # a broken artifact.
+          if ! unzip -l dist/*.whl | grep -q ' fintekkers/wrappers/models/security/hierarchy.json$'; then
+              echo "ERROR: built wheel does not bundle hierarchy.json — refusing to publish."
+              echo "       see ledger-models-protos/registry-versioning.md and"
+              echo "       check-python-wheel-hierarchy.sh for the regression history."
+              exit 1
+          fi
+
           pip3 install twine
-          
+
           twine upload -u __token__ -p "${{ secrets.PYPI_TOKEN }}" --repository pypi dist/*

--- a/check-python-wheel-hierarchy.sh
+++ b/check-python-wheel-hierarchy.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# check-python-wheel-hierarchy.sh
+#
+# Pre-release guard. Builds the Python wheel and inspects it to confirm
+# hierarchy.json is bundled at the expected path inside the package.
+#
+# Why: v0.2.1 shipped without hierarchy.json in the wheel because
+# MANIFEST.in didn't include *.json. Consumers (market-data-inputs) had
+# to vendor the file into their own repos as a workaround. v0.2.2 adds
+# `recursive-include fintekkers *.json` to MANIFEST.in to fix this;
+# this script makes the breakage harder to ship again by failing the
+# release if the wheel ever loses the file.
+#
+# Exits 0 if hierarchy.json is present at the expected path inside the
+# built wheel. Exits 1 with a remediation message otherwise.
+#
+# Pair script: sync-hierarchy-mirrors.sh materializes the mirror from
+# the canonical. setup.py invokes it pre-build for local dev; CI's
+# pypi-publish workflow invokes it explicitly. This guard runs after
+# the wheel is built and unpacks it to verify the result.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PY_DIR="${REPO_ROOT}/ledger-models-python"
+EXPECTED_PATH="fintekkers/wrappers/models/security/hierarchy.json"
+
+if [[ ! -f "${PY_DIR}/setup.py" ]]; then
+    echo "ERROR: ${PY_DIR}/setup.py not found" >&2
+    exit 1
+fi
+
+# Build into a temp dist so we don't disturb whatever's in dist/ already.
+BUILD_DIR="$(mktemp -d)"
+trap 'rm -rf "$BUILD_DIR"' EXIT
+
+(
+    cd "$PY_DIR"
+    BUILD_VERSION="0.0.0-check" python3 setup.py bdist_wheel \
+        --dist-dir "$BUILD_DIR" >/dev/null 2>&1
+)
+
+WHL="$(ls "$BUILD_DIR"/*.whl 2>/dev/null | head -1)"
+if [[ -z "$WHL" ]]; then
+    echo "ERROR: no wheel produced under $BUILD_DIR" >&2
+    exit 1
+fi
+
+# Inspect the wheel — zip archives expose their file listing via unzip -l.
+if unzip -l "$WHL" 2>/dev/null | grep -q " $EXPECTED_PATH$"; then
+    echo "OK: $EXPECTED_PATH present in $(basename "$WHL")"
+    exit 0
+fi
+
+echo "ERROR: $EXPECTED_PATH MISSING from the built wheel." >&2
+echo "" >&2
+echo "Built: $(basename "$WHL")" >&2
+echo "" >&2
+echo "Remediation:" >&2
+echo "  1. Verify MANIFEST.in includes 'recursive-include fintekkers *.json'." >&2
+echo "  2. Verify ledger-models-python/fintekkers/wrappers/models/security/hierarchy.json" >&2
+echo "     exists (run ./sync-hierarchy-mirrors.sh from the repo root)." >&2
+echo "  3. Re-build: rm -rf dist build; BUILD_VERSION=test python3 setup.py bdist_wheel" >&2
+echo "  4. Re-inspect: unzip -l dist/*.whl | grep hierarchy.json" >&2
+echo "" >&2
+echo "Background: v0.2.1 shipped without hierarchy.json, forcing consumers to" >&2
+echo "vendor it. v0.2.2 fixed MANIFEST.in. This guard prevents regressing." >&2
+exit 1

--- a/ledger-models-protos/registry-versioning.md
+++ b/ledger-models-protos/registry-versioning.md
@@ -88,6 +88,19 @@ Why mirrors are still needed at all: cargo publish / npm publish / pip wheel eac
 
 Net effect: one file in git, three transient mirrors at build/publish time, zero opportunity for committed drift.
 
+### Bundling the mirror in each language's tarball
+
+Materializing the mirror to the right path on disk isn't enough — each language's package manifest also has to **bundle** the file into the published artifact:
+
+| Language | Where bundling is declared | Notes |
+| --- | --- | --- |
+| Rust | `ledger-models-rust/Cargo.toml` → `include = [..., "hierarchy.json"]` | Without the include list entry, `cargo publish` skips the file. Verified with `cargo package --list`. |
+| Python | `ledger-models-python/MANIFEST.in` → `recursive-include fintekkers *.json` | Without the recursive-include, `bdist_wheel` skips `*.json` even with `include_package_data=True`. This is the v0.2.1 regression that forced market-data-inputs to vendor the file. Guard: `./check-python-wheel-hierarchy.sh` builds + inspects. |
+| JS | `ledger-models-javascript/package.json` (default `npm pack` behavior with no `files` array) | `npm pack` bundles non-gitignored files at the package root by default; the repo-root `.gitignore` doesn't propagate into npm. Verified with `npm pack --dry-run`. |
+| Java | `ledger-models-java/build.gradle` → `processResources` from `../ledger-models-protos` | Java reads the canonical directly at build time; no mirror needed. |
+
+If you change any of these manifests, run the language-specific dry-run (`cargo package --list`, `unzip -l dist/*.whl`, `npm pack --dry-run`) and grep for `hierarchy.json` before merging.
+
 ## What is *not* a registry change
 
 The registry classifies **legal form**. It does not classify:

--- a/ledger-models-python/MANIFEST.in
+++ b/ledger-models-python/MANIFEST.in
@@ -3,3 +3,14 @@ include README.rst
 include fintekkers/py.typed
 
 recursive-include * *.pyi
+
+# Bundle hierarchy.json (canonical product registry, mirrored from
+# ledger-models-protos/hierarchy.json into the package directory by
+# sync-hierarchy-mirrors.sh) and catalog/*.json (field + measure
+# catalogs distributed by compile.sh). Without this, wheels don't ship
+# the runtime data files and ProductHierarchy fails to load on
+# consumer installs (forcing the vendoring-into-consumer-repo
+# antipattern). Pattern is `recursive-include fintekkers *.json`
+# rather than restricting to specific subdirs so future registry
+# files are picked up automatically.
+recursive-include fintekkers *.json

--- a/ledger-models-python/setup.py
+++ b/ledger-models-python/setup.py
@@ -1,7 +1,8 @@
 from setuptools import setup, find_packages
-import os 
+import os
+import subprocess
 
-VERSION = '0.0.0' 
+VERSION = '0.0.0'
 DESCRIPTION = 'Fintekkers Ledger Models python package'
 LONG_DESCRIPTION = 'Contains the generated python code for the ledger models protos, as well as hand-written wrapper code. See the package url to link to the proto defintions'
 
@@ -10,6 +11,24 @@ if 'BUILD_VERSION' in os.environ:
     print("************OVERRIDING VERSION FROM ENVIRONMENT******************")
     print("******************************************")
     VERSION = os.environ.get('BUILD_VERSION')
+
+# Materialize hierarchy.json into the package directory before the wheel
+# bundles it. The canonical lives at ../ledger-models-protos/hierarchy.json
+# (one source of truth across all 4 languages) and is mirrored into
+# fintekkers/wrappers/models/security/hierarchy.json by
+# sync-hierarchy-mirrors.sh at the repo root. CI's pypi-publish workflow
+# runs that script before invoking setup.py, but local `python setup.py
+# bdist_wheel` builds need the same materialization. Best-effort: if the
+# script isn't reachable (sdist already-unpacked, vendored consumer
+# build, etc.) skip silently — the mirror may already be present.
+_repo_root_sync = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                               '..', 'sync-hierarchy-mirrors.sh')
+if os.path.exists(_repo_root_sync):
+    try:
+        subprocess.run([_repo_root_sync], check=True)
+    except subprocess.CalledProcessError as e:
+        print(f"WARN: sync-hierarchy-mirrors.sh failed (exit {e.returncode}); "
+              f"build will fail later if hierarchy.json is missing.")
 
 setup(
     name = "fintekkers_ledger_models",

--- a/ledger-models-python/test/wrappers/models/security/test_product_hierarchy.py
+++ b/ledger-models-python/test/wrappers/models/security/test_product_hierarchy.py
@@ -1,0 +1,96 @@
+"""Tests for the ProductHierarchy registry helper.
+
+The helper loads hierarchy.json via two strategies (see
+fintekkers/wrappers/models/security/product_hierarchy.py::_load_registry):
+
+  1. Packaged resource — alongside the module after wheel install.
+  2. Development-checkout fallback — walks up for
+     ledger-models-protos/hierarchy.json.
+
+v0.2.1 shipped a broken wheel that didn't include hierarchy.json
+(MANIFEST.in didn't list *.json), so strategy 1 always failed for
+consumers and forced the vendoring-into-consumer-repo antipattern
+(market-data-inputs PR #14). v0.2.2 added 'recursive-include
+fintekkers *.json' to MANIFEST.in.
+
+These tests exercise the helper end-to-end. They pass in both the
+development checkout (strategy 2) and the wheel-installed environment
+(strategy 1), so a future MANIFEST.in regression that breaks the
+packaged-resource path won't be caught by these tests alone — see
+check-python-wheel-hierarchy.sh for the post-build wheel inspection
+that DOES catch that regression.
+"""
+
+import pytest
+
+from fintekkers.wrappers.models.security import product_hierarchy as PH
+
+
+def test_registry_loads_without_error():
+    """If hierarchy.json can't be found by either strategy, this fails
+    at import-via-call time with FileNotFoundError. The bug v0.2.2
+    fixes is that strategy 1 wasn't usable for consumers because the
+    wheel didn't bundle the file; this test passing means at least one
+    of the two load strategies worked."""
+    types = PH.all_product_types()
+    assert isinstance(types, list)
+    assert len(types) > 0
+
+
+def test_active_product_types_match_m1_spec_count():
+    """M1 of #257 locked in 26 active leaves; the count is a sentinel
+    for accidental dropping or reverting of registry entries."""
+    active = PH.active_product_types()
+    assert len(active) == 26, f"expected 26 active leaves, got {len(active)}: {active}"
+
+
+def test_active_product_types_include_known_m1_leaves():
+    """Spot-check against the canonical M1 spec leaves to catch a
+    case where the loader returns a wrong / stale registry."""
+    active = set(PH.active_product_types())
+    for expected in [
+        "TBILL", "TREASURY_NOTE", "TREASURY_BOND", "TIPS", "TREASURY_FRN",
+        "STRIPS", "SOVEREIGN_BOND", "CORP_BOND", "MUNI_BOND",
+        "COMMON_STOCK", "PREFERRED_STOCK", "ADR", "ETF",
+        "EQUITY_INDEX", "BOND_INDEX", "COMMODITY_INDEX", "VIX_SPOT",
+        "CPI_SERIES", "SOFR_SERIES",
+        "CURRENCY", "FX_SPOT", "MONEY_MARKET_FUND",
+        "CRYPTOCURRENCY", "STABLECOIN",
+        "GOLD", "SILVER",
+    ]:
+        assert expected in active, f"{expected} missing from active product types"
+
+
+def test_descendants_of_bond_walks_transitively():
+    descendants = set(PH.descendants_of("BOND"))
+    for expected in ["TBILL", "TREASURY_NOTE", "CORP_BOND", "MUNI_BOND"]:
+        assert expected in descendants, f"{expected} missing from descendants_of('BOND')"
+
+
+def test_is_descendant_of_traverses_abstract_intermediates():
+    assert PH.is_descendant_of("TBILL", "GOV_BOND")
+    assert PH.is_descendant_of("TBILL", "BOND")           # transitive through GOV_BOND
+    assert PH.is_descendant_of("CORP_BOND", "BOND")        # transitive through CREDIT_BOND
+    assert not PH.is_descendant_of("TBILL", "STOCK")
+    assert not PH.is_descendant_of("BOND", "BOND")         # strict descendant
+
+
+def test_classification_lookups():
+    assert PH.asset_class_of("TBILL") == "RATES"
+    assert PH.asset_class_of("CORP_BOND") == "CREDIT"
+    assert PH.asset_class_of("STABLECOIN") == "CRYPTO"
+    assert PH.asset_class_of("FX_SPOT") == "FX"
+    assert PH.instrument_type_of("TBILL") == "CASH"
+    assert PH.instrument_type_of("EQUITY_INDEX") == "REFERENCE_INDEX"
+    assert PH.asset_class_of("BOND") is None  # abstract node has no asset_class
+
+
+def test_label_returns_human_readable_string():
+    assert PH.label_of("TBILL") == "Treasury Bill"
+    assert PH.label_of("STABLECOIN") == "Stablecoin"
+    assert PH.label_of("NOT_A_REAL_LEAF") is None
+
+
+def test_instrument_types_are_three_known_values():
+    its = PH.all_instrument_types()
+    assert sorted(its) == ["CASH", "DERIVATIVE", "REFERENCE_INDEX"]

--- a/release.sh
+++ b/release.sh
@@ -104,6 +104,17 @@ preflight() {
     # (see .github/workflows/{cargo,pypi,npmjs,npm}-publish.yml), so
     # no local mirror check is needed in this preflight.
 
+    # v0.2.2 — verify the Python wheel actually bundles hierarchy.json.
+    # v0.2.1 shipped a broken wheel that forced consumers to vendor the
+    # file (market-data-inputs PR #14). Build the wheel locally and
+    # inspect; fail fast if the data file is missing. Skip the check if
+    # python3 isn't available (rare on a dev machine that ships
+    # ledger-models, but be permissive).
+    if command -v python3 >/dev/null 2>&1; then
+        ./check-python-wheel-hierarchy.sh >/dev/null 2>&1 \
+            || die "Python wheel does not bundle hierarchy.json. Run ./check-python-wheel-hierarchy.sh for details. Do NOT release until fixed — see registry-versioning.md."
+    fi
+
     success "Pre-flight passed."
 }
 


### PR DESCRIPTION
## Summary

The v0.2.1 Python wheel didn't ship `hierarchy.json`. `MANIFEST.in` only listed `*.pyi`, so `bdist_wheel` silently dropped all `.json` files even with `include_package_data=True`. Consumers couldn't load the registry from the installed wheel, and [market-data-inputs PR #14](https://github.com/FinTekkers/market-data-inputs/pull/14) had to vendor a copy of `hierarchy.json` into the consumer repo as a workaround.

This PR fixes the wheel, eliminates the vendoring antipattern, and adds two guards so the regression can't ship again.

Refs: [second-brain#257](https://github.com/FinTekkers/second-brain/issues/257) (M1 follow-up), [market-data-inputs#14](https://github.com/FinTekkers/market-data-inputs/pull/14).

## Bug reproduction (pre-fix)

```
cd ledger-models-python
BUILD_VERSION=0.0.0-test python3 setup.py bdist_wheel
unzip -l dist/*.whl | grep "\.json"
                                          ← (empty: zero .json files)
unzip -l dist/*.whl | grep -i hierarchy
fintekkers/wrappers/models/security/product_hierarchy.py
                                          ← only the .py, not the .json
```

The wheel also silently dropped `catalog/fields.json` + `catalog/measures.json` (same root cause).

## Fix

| File | Change |
| --- | --- |
| `ledger-models-python/MANIFEST.in` | Add `recursive-include fintekkers *.json` — picks up hierarchy.json + catalog files. Recursive pattern so future registry files are bundled automatically. |
| `ledger-models-python/setup.py` | Pre-build invokes `../sync-hierarchy-mirrors.sh` if reachable. CI workflows already do this explicitly post-checkout (PR #206); this covers local `python setup.py bdist_wheel` runs. Best-effort, no-op when not in repo context. |

Post-fix:

```
unzip -l dist/*.whl | grep "\.json"
     8936  ...  fintekkers/catalog/fields.json
    12617  ...  fintekkers/catalog/measures.json
    14719  ...  fintekkers/wrappers/models/security/hierarchy.json
```

## Two new guards (so this can't regress)

### `check-python-wheel-hierarchy.sh` (NEW)

Standalone script. Builds the wheel into a temp dir, inspects via `unzip -l`, exits 1 with a clear remediation message if `hierarchy.json` is missing. Locally verified both happy path (file present → exit 0) and negative case (broken MANIFEST.in → exit 1 + diagnosis).

### `release.sh` preflight

Now calls `check-python-wheel-hierarchy.sh` and dies on failure. Tag-push is blocked if the wheel would ship broken.

### `.github/workflows/pypi-publish.yml` — inline check

Between `setup.py sdist bdist_wheel` and `twine upload`, the workflow greps the built wheel for `hierarchy.json`. Workflow fails before publish if missing. Belt-and-suspenders with the preflight (catches the case where someone bypasses `release.sh`).

## New Python test

`ledger-models-python/test/wrappers/models/security/test_product_hierarchy.py` — 8 tests exercising the helper:

- `test_registry_loads_without_error`
- `test_active_product_types_match_m1_spec_count` (26 leaves sentinel)
- `test_active_product_types_include_known_m1_leaves`
- `test_descendants_of_bond_walks_transitively`
- `test_is_descendant_of_traverses_abstract_intermediates`
- `test_classification_lookups`
- `test_label_returns_human_readable_string`
- `test_instrument_types_are_three_known_values`

All 8 pass. Note: these tests pass in dev-checkout even with a broken MANIFEST.in (load strategy 2 — walk up to `ledger-models-protos/`), so they alone don't catch the wheel regression. `check-python-wheel-hierarchy.sh` is the post-build inspection that does.

## Cross-language audit

| Language | State | Notes |
| --- | --- | --- |
| **Rust** | ✅ already correct | `ledger-models-rust/hierarchy.json` mirror (gitignored, materialized by sync), `Cargo.toml` `include` list explicitly bundles `hierarchy.json`. `cargo package --list` confirmed in v0.2.0 hotfix. Content also inlined in compiled lib via `include_str!`. |
| **JS** | ✅ already correct | `ledger-models-javascript/hierarchy.json` mirror (gitignored). `npm pack --dry-run` confirms 14.7kB hierarchy.json bundled (npm bundles non-gitignored package-root files by default; repo-root .gitignore doesn't propagate into npm). The TS code also embeds the JSON via `resolveJsonModule + import` — content inlined in compiled .js as defense-in-depth. |
| **Java** | ✅ not affected | Gradle `processResources` copies the canonical from `../ledger-models-protos/` into the jar at build time. No mirror needed; nothing to break. |
| **Python** | ❌ → ✅ | The only broken language. This PR fixes it. |

## End-to-end verification

```
./compile.sh --skip-integration
RESULT: ALL PASSED
  Rust:       PASS / PASS
  Java:       PASS / PASS
  JavaScript: PASS / PASS
  Python:     PASS / PASS  (8 new tests included)

./check-python-wheel-hierarchy.sh
OK: fintekkers/wrappers/models/security/hierarchy.json present in fintekkers_ledger_models-0.0.0_check-py3-none-any.whl
```

## Downstream

Once v0.2.2 ships:
- [market-data-inputs PR #14](https://github.com/FinTekkers/market-data-inputs/pull/14) bumps the `fintekkers_ledger_models` dep from 0.2.1 → 0.2.2, deletes its vendored `hierarchy.json`, and reads from `fintekkers.wrappers.models.security.product_hierarchy` (which loads via strategy 1 = packaged resource).

## Doc update

`ledger-models-protos/registry-versioning.md` gains a "Bundling the mirror in each language's tarball" subsection documenting each language's manifest requirement and the dry-run command to verify bundling before merging a manifest change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)