### PR TITLE
ci(#288, #297): test discipline + silent-failure guardrails (multi-lang)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# ledger-models pre-push: detect which sub-projects changed since the
+# remote tracking ref and run only those test suites.
+#
+# Setup once per clone: `git config core.hooksPath .githooks`
+# (or run `./scripts/install-hooks.sh` if added to the repo).
+#
+# See second-brain/processes/test-discipline.md.
+
+set -euo pipefail
+
+# Determine range of commits being pushed. `git push` passes refs on
+# stdin — fall back to comparing HEAD against origin/main if not.
+if [ -t 0 ]; then
+  base="$(git merge-base HEAD origin/main 2>/dev/null || echo origin/main)"
+else
+  range="$(cat)"
+  base=$(echo "$range" | awk '{print $4}' | head -1)
+  [ -z "$base" ] || [ "$base" = "0000000000000000000000000000000000000000" ] && \
+    base="$(git merge-base HEAD origin/main 2>/dev/null || echo origin/main)"
+fi
+
+changed=$(git diff --name-only "$base"...HEAD 2>/dev/null || git diff --name-only HEAD)
+echo "pre-push: changed files since $base:"
+echo "$changed" | sed 's/^/  /' | head -20
+echo
+
+run_python=0; run_rust=0; run_java=0; run_js=0; run_protos=0; run_root=0
+while IFS= read -r f; do
+  case "$f" in
+    ledger-models-python/*)     run_python=1 ;;
+    ledger-models-rust/*)       run_rust=1 ;;
+    ledger-models-java/*)       run_java=1 ;;
+    ledger-models-javascript/*) run_js=1 ;;
+    ledger-models-protos/*)     run_protos=1 ;;
+    .github/*|.githooks/*|scripts/*|*.sh|*.py|README.md|LICENSE.txt) run_root=1 ;;
+    *) ;;
+  esac
+done <<< "$changed"
+
+# Proto changes ripple to every binding; run all suites.
+if [ $run_protos -eq 1 ]; then
+  run_python=1; run_rust=1; run_java=1; run_js=1
+fi
+
+# Root scripts (.github, .githooks, top-level *.sh): just run lint scripts.
+if [ $run_root -eq 1 ] && [ $((run_python + run_rust + run_java + run_js)) -eq 0 ]; then
+  echo "pre-push: only root/script files changed; running lint scripts only."
+  bash .github/scripts/ban-broad-except.sh
+  exit $?
+fi
+
+if [ $run_python -eq 1 ]; then
+  echo "==> ledger-models-python: pytest -m 'not integration'"
+  (
+    cd ledger-models-python
+    # Source the per-project venv if present so pytest/ruff resolve.
+    [ -f venv/bin/activate ] && . venv/bin/activate
+    python -m pytest -m 'not integration' -x -q
+  )
+fi
+if [ $run_rust -eq 1 ]; then
+  echo "==> ledger-models-rust: cargo test --lib"
+  (cd ledger-models-rust && cargo test --lib --quiet)
+fi
+if [ $run_java -eq 1 ]; then
+  echo "==> ledger-models-java: ./gradlew test"
+  (cd ledger-models-java && ./gradlew test --quiet)
+fi
+if [ $run_js -eq 1 ]; then
+  echo "==> ledger-models-javascript: npm test"
+  (cd ledger-models-javascript && npm test --silent)
+fi
+
+echo "==> .github/scripts/ban-broad-except.sh"
+bash .github/scripts/ban-broad-except.sh
+
+if command -v python3 >/dev/null 2>&1 \
+   && python3 -c "import sys; sys.exit(0 if sys.version_info >= (3,11) else 1)" 2>/dev/null; then
+  echo "==> .github/scripts/check-downgrades.py (warn-only)"
+  python3 .github/scripts/check-downgrades.py --base origin/main || \
+    echo "downgrade-detector: above will block CI. Add DOWNGRADE-EXCEPTION: <rationale> + <upstream-issue-url> to PR body, or revert."
+fi

--- a/.github/scripts/ban-broad-except.sh
+++ b/.github/scripts/ban-broad-except.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Ban silent broad-catch patterns across all languages in this repo.
+# Counterpart to ruff BLE001 for Python; cross-language coverage for the
+# rest. See second-brain/processes/test-discipline.md (silent-failure
+# guardrails) and #297.
+#
+# A broad catch is fine ONLY when it logs *and* either re-raises or marks
+# the operation failed. A bare `pass` (or empty block) is never OK in
+# production code paths.
+#
+# Excludes: vendored deps, build artifacts, tests/ (test discards are
+# usually deliberate), and generated proto code.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+fail=0
+
+# ---------- Python: bare/broad except followed by `pass` ----------
+# This script catches only the egregious silent-pass shape. Nuanced cases
+# (catch + log without raise; catch + set_exception + raise) are handled
+# by `ruff` rule BLE001 in CI for ledger-models-python.
+py_hits=$(
+  grep -rEnA1 --include='*.py' \
+    -e '^[[:space:]]*except[[:space:]]*:[[:space:]]*$' \
+    -e '^[[:space:]]*except[[:space:]]+(Exception|BaseException)[[:space:]]*:[[:space:]]*$' \
+    "$ROOT" \
+    --exclude-dir=venv --exclude-dir=.venv --exclude-dir=build --exclude-dir=node_modules \
+    --exclude-dir=test --exclude-dir=tests --exclude-dir=target --exclude-dir=.github 2>/dev/null \
+  | grep -B1 -E '^[^:]+-[[:space:]]*pass[[:space:]]*$' || true
+)
+if [ -n "$py_hits" ]; then
+  echo "ban-broad-except: Python broad/bare excepts (use a narrow exception or log_and_raise):"
+  echo "$py_hits" | sed 's/^/  /'
+  fail=1
+fi
+
+# ---------- Java: catch (Exception|Throwable ...) { } empty ----------
+java_hits=$(
+  grep -rEn --include='*.java' \
+    -e 'catch[[:space:]]*\([[:space:]]*(Exception|Throwable|RuntimeException)[[:space:]]+[A-Za-z_]+[[:space:]]*\)[[:space:]]*\{[[:space:]]*\}' \
+    "$ROOT" \
+    --exclude-dir=node_modules --exclude-dir=build --exclude-dir=target \
+    --exclude-dir=src/test --exclude-dir=test --exclude-dir=.github 2>/dev/null || true
+)
+if [ -n "$java_hits" ]; then
+  echo "ban-broad-except: Java empty catch (Exception/Throwable):"
+  echo "$java_hits" | sed 's/^/  /'
+  fail=1
+fi
+
+# ---------- JS/TS: empty catch (e) { } ----------
+js_hits=$(
+  grep -rEn --include='*.js' --include='*.ts' --include='*.svelte' \
+    -e 'catch[[:space:]]*\([^)]*\)[[:space:]]*\{[[:space:]]*\}' \
+    "$ROOT" \
+    --exclude-dir=node_modules --exclude-dir=build --exclude-dir=dist \
+    --exclude-dir=tests --exclude-dir=test --exclude-dir=.svelte-kit \
+    --exclude-dir=.github 2>/dev/null || true
+)
+if [ -n "$js_hits" ]; then
+  echo "ban-broad-except: JS/TS empty catch:"
+  echo "$js_hits" | sed 's/^/  /'
+  fail=1
+fi
+
+# ---------- Rust: .ok() / .unwrap_or_default() on a Result that swallows Err? ----------
+# Heuristic: flag `let _ = <expr>?` (impossible) and `.ok();` on its own line
+# (clearly discarding). Rust's strict types make this a much smaller surface.
+rust_hits=$(
+  grep -rEn --include='*.rs' \
+    -e '^\s*[A-Za-z_].*\.ok\(\)\s*;[[:space:]]*$' \
+    "$ROOT" \
+    --exclude-dir=target --exclude-dir=tests --exclude-dir=.github 2>/dev/null || true
+)
+if [ -n "$rust_hits" ]; then
+  echo "ban-broad-except: Rust Result silently discarded with .ok();"
+  echo "$rust_hits" | sed 's/^/  /'
+  fail=1
+fi
+
+if [ $fail -ne 0 ]; then
+  echo
+  echo "Per processes/test-discipline.md (silent-failure guardrails) and #297:"
+  echo "  - Use a narrow exception type, or"
+  echo "  - log AND raise / mark the operation failed, or"
+  echo "  - if the catch is genuinely intended (cleanup-best-effort, etc.),"
+  echo "    annotate with the narrowest possible type and a comment."
+  exit 1
+fi

--- a/.github/scripts/check-downgrades.py
+++ b/.github/scripts/check-downgrades.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+"""
+Block consumer-side dependency downgrades and new override/patch blocks.
+
+Implements the "fix upstream first" rule from
+second-brain/processes/test-discipline.md. Run in CI on every PR.
+
+Diffs the package manifests in the working tree against a base ref, flags:
+  - Any version constraint whose lower bound decreased (e.g. ^4.0.2 -> ^3.21.4)
+  - New top-level npm `overrides` / `resolutions` entries
+  - New Cargo `[patch.crates-io]` / `[patch.<reg>]` entries
+  - New `[tool.uv.sources]` overrides in pyproject
+
+A `DOWNGRADE-EXCEPTION: <rationale> + <upstream-issue-url>` line in the
+PR description (passed via --pr-body or GITHUB_EVENT_PATH) suppresses the
+failure. Findings still print so the exception is auditable.
+
+Supports: package.json, Cargo.toml, pyproject.toml, requirements.txt, go.mod
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from typing import Iterable
+
+try:
+    import tomllib  # 3.11+
+except ModuleNotFoundError:
+    try:
+        import tomli as tomllib  # type: ignore
+    except ModuleNotFoundError:
+        tomllib = None  # type: ignore
+
+
+MANIFESTS = ("package.json", "Cargo.toml", "pyproject.toml", "requirements.txt", "go.mod")
+
+
+def git_show(ref: str, path: str) -> str | None:
+    r = subprocess.run(["git", "show", f"{ref}:{path}"], capture_output=True, text=True)
+    return r.stdout if r.returncode == 0 else None
+
+
+def lower_bound(constraint: str) -> tuple[int, ...] | None:
+    """Extract the numeric lower bound from a version constraint.
+
+    Handles: 1.2.3, ^1.2.3, ~1.2.3, >=1.2.3, >=1.2,<2, =1.2.3, 1.2.*
+    Returns None if unparseable (caller should skip the comparison).
+    """
+    m = re.search(r"(\d+)(?:\.(\d+))?(?:\.(\d+))?", constraint)
+    if not m:
+        return None
+    return tuple(int(g or 0) for g in m.groups())
+
+
+def cmp_constraints(old: str, new: str) -> bool:
+    """True if `new` represents a lower lower-bound than `old`."""
+    a, b = lower_bound(old), lower_bound(new)
+    if a is None or b is None:
+        return False
+    return b < a
+
+
+def walk_npm(old: dict, new: dict) -> Iterable[str]:
+    for key in ("dependencies", "devDependencies", "peerDependencies", "optionalDependencies"):
+        old_d, new_d = old.get(key, {}) or {}, new.get(key, {}) or {}
+        for name, new_v in new_d.items():
+            if not isinstance(new_v, str):
+                continue
+            old_v = old_d.get(name)
+            if isinstance(old_v, str) and cmp_constraints(old_v, new_v):
+                yield f"{key}: {name} {old_v} -> {new_v}"
+    for block in ("overrides", "resolutions"):
+        old_b, new_b = old.get(block, {}) or {}, new.get(block, {}) or {}
+        for name in new_b.keys() - old_b.keys():
+            yield f"new `{block}` entry '{name}' (transitive pin = same as downgrade)"
+
+
+def _flatten_cargo_dep(v) -> str | None:
+    if isinstance(v, str):
+        return v
+    if isinstance(v, dict):
+        return v.get("version")
+    return None
+
+
+def walk_cargo(old: dict, new: dict) -> Iterable[str]:
+    for key in ("dependencies", "dev-dependencies", "build-dependencies"):
+        old_d, new_d = old.get(key, {}) or {}, new.get(key, {}) or {}
+        for name, new_v in new_d.items():
+            new_s = _flatten_cargo_dep(new_v)
+            old_s = _flatten_cargo_dep(old_d.get(name))
+            if new_s and old_s and cmp_constraints(old_s, new_s):
+                yield f"{key}: {name} {old_s} -> {new_s}"
+    old_patch, new_patch = old.get("patch", {}) or {}, new.get("patch", {}) or {}
+    for registry, entries in new_patch.items():
+        old_entries = old_patch.get(registry, {}) or {}
+        for name in (entries or {}).keys() - old_entries.keys():
+            yield f"new `[patch.{registry}]` entry '{name}' (consumer-side override = same as downgrade)"
+
+
+def walk_pyproject(old: dict, new: dict) -> Iterable[str]:
+    # PEP 621 dependencies = ["foo>=1,<2", ...]
+    def parse_list(deps):
+        out = {}
+        for d in deps or []:
+            m = re.match(r"^([A-Za-z0-9_.\-]+)\s*([<>=!~^].*)?$", d.strip())
+            if m:
+                out[m.group(1).lower()] = (m.group(2) or "").strip()
+        return out
+
+    old_proj, new_proj = old.get("project", {}) or {}, new.get("project", {}) or {}
+    old_d, new_d = parse_list(old_proj.get("dependencies")), parse_list(new_proj.get("dependencies"))
+    for name, new_v in new_d.items():
+        old_v = old_d.get(name)
+        if old_v and new_v and cmp_constraints(old_v, new_v):
+            yield f"[project.dependencies]: {name} {old_v} -> {new_v}"
+
+    # Poetry: [tool.poetry.dependencies]
+    old_poe = (old.get("tool", {}) or {}).get("poetry", {}).get("dependencies", {}) or {}
+    new_poe = (new.get("tool", {}) or {}).get("poetry", {}).get("dependencies", {}) or {}
+    for name, new_v in new_poe.items():
+        if name == "python":
+            continue
+        new_s = new_v if isinstance(new_v, str) else (new_v.get("version") if isinstance(new_v, dict) else None)
+        old_v = old_poe.get(name)
+        old_s = old_v if isinstance(old_v, str) else (old_v.get("version") if isinstance(old_v, dict) else None)
+        if new_s and old_s and cmp_constraints(old_s, new_s):
+            yield f"[tool.poetry.dependencies]: {name} {old_s} -> {new_s}"
+
+    # uv override block
+    old_uv = (old.get("tool", {}) or {}).get("uv", {}).get("sources", {}) or {}
+    new_uv = (new.get("tool", {}) or {}).get("uv", {}).get("sources", {}) or {}
+    for name in new_uv.keys() - old_uv.keys():
+        yield f"new `[tool.uv.sources]` entry '{name}' (consumer-side override = same as downgrade)"
+
+
+def walk_requirements(old_text: str, new_text: str) -> Iterable[str]:
+    def parse(text):
+        out = {}
+        for line in (text or "").splitlines():
+            line = line.split("#", 1)[0].strip()
+            if not line or line.startswith("-"):
+                continue
+            m = re.match(r"^([A-Za-z0-9_.\-]+)\s*([<>=!~^].*)?$", line)
+            if m:
+                out[m.group(1).lower()] = (m.group(2) or "").strip()
+        return out
+    old_d, new_d = parse(old_text), parse(new_text)
+    for name, new_v in new_d.items():
+        old_v = old_d.get(name)
+        if old_v and new_v and cmp_constraints(old_v, new_v):
+            yield f"{name} {old_v} -> {new_v}"
+
+
+def walk_gomod(old_text: str, new_text: str) -> Iterable[str]:
+    def parse(text):
+        out = {}
+        for line in (text or "").splitlines():
+            line = line.strip()
+            m = re.match(r"^(?:require\s+)?([\w./\-]+)\s+v(\S+)", line)
+            if m and not line.startswith("//"):
+                out[m.group(1)] = m.group(2)
+        return out
+    old_d, new_d = parse(old_text), parse(new_text)
+    for name, new_v in new_d.items():
+        old_v = old_d.get(name)
+        if old_v and new_v and cmp_constraints(old_v, new_v):
+            yield f"{name} v{old_v} -> v{new_v}"
+
+
+def parse_toml(text: str) -> dict:
+    if tomllib is None:
+        print("WARN: tomllib/tomli not available; skipping TOML manifest", file=sys.stderr)
+        return {}
+    return tomllib.loads(text)
+
+
+def find_manifests(base: str) -> list[str]:
+    paths = []
+    for m in MANIFESTS:
+        r = subprocess.run(
+            ["git", "diff", "--name-only", base, "--", m, f"**/{m}"],
+            capture_output=True, text=True,
+        )
+        paths.extend(p for p in r.stdout.splitlines() if p)
+    # Always include root manifests even if diff missed (e.g. first commit)
+    for m in MANIFESTS:
+        if os.path.exists(m) and m not in paths:
+            paths.append(m)
+    return sorted(set(paths))
+
+
+def check_one(path: str, base: str) -> list[str]:
+    old_text = git_show(base, path) or ""
+    try:
+        with open(path) as f:
+            new_text = f.read()
+    except FileNotFoundError:
+        return []
+    if old_text == new_text:
+        return []
+    name = os.path.basename(path)
+    findings = []
+    if name == "package.json":
+        findings = list(walk_npm(json.loads(old_text or "{}"), json.loads(new_text)))
+    elif name == "Cargo.toml":
+        findings = list(walk_cargo(parse_toml(old_text), parse_toml(new_text)))
+    elif name == "pyproject.toml":
+        findings = list(walk_pyproject(parse_toml(old_text), parse_toml(new_text)))
+    elif name == "requirements.txt":
+        findings = list(walk_requirements(old_text, new_text))
+    elif name == "go.mod":
+        findings = list(walk_gomod(old_text, new_text))
+    return [f"  {path}: {f}" for f in findings]
+
+
+def get_pr_body(pr_body_arg: str | None) -> str:
+    if pr_body_arg:
+        return pr_body_arg
+    event_path = os.environ.get("GITHUB_EVENT_PATH")
+    if event_path and os.path.exists(event_path):
+        try:
+            with open(event_path) as f:
+                return ((json.load(f).get("pull_request") or {}).get("body") or "")
+        except Exception:
+            return ""
+    return ""
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--base", default=os.environ.get("GITHUB_BASE_REF") or "origin/main")
+    p.add_argument("--pr-body", default=None, help="PR description text (overrides GITHUB_EVENT_PATH)")
+    args = p.parse_args()
+
+    base = args.base if "/" in args.base else f"origin/{args.base}"
+    subprocess.run(["git", "fetch", "origin", "--quiet"], check=False)
+
+    findings: list[str] = []
+    for path in find_manifests(base):
+        findings.extend(check_one(path, base))
+
+    if not findings:
+        return 0
+
+    print("downgrade-detector: consumer-side downgrades or override blocks found:")
+    for f in findings:
+        print(f)
+    print()
+
+    body = get_pr_body(args.pr_body)
+    if re.search(r"^DOWNGRADE-EXCEPTION:\s*\S", body, re.MULTILINE):
+        print("DOWNGRADE-EXCEPTION present in PR body — allowing.")
+        return 0
+
+    print(
+        "Per processes/test-discipline.md (fix-upstream-first): the default fix is in the\n"
+        "library, not the consumer. To override, add to the PR description:\n"
+        "  DOWNGRADE-EXCEPTION: <rationale> + <upstream-issue-url>\n"
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,8 @@ jobs:
         working-directory: ledger-models-python
         run: |
           python -m pip install --upgrade pip
-          pip install ruff pytest grpcio grpcio-tools protobuf python-dateutil
+          pip install -r requirements.txt
+          pip install ruff
 
       - name: ruff check (silent-failure guardrail — BLE001)
         working-directory: ledger-models-python
@@ -48,6 +49,9 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
+
+      - name: Materialize hierarchy.json mirror (cargo include_str! target)
+        run: ./sync-hierarchy-mirrors.sh
 
       - name: cargo test --lib
         working-directory: ledger-models-rust
@@ -85,6 +89,9 @@ jobs:
       - name: npm ci
         working-directory: ledger-models-javascript
         run: npm ci --ignore-scripts
+
+      - name: Materialize hierarchy.json mirror (jest resolveJsonModule target)
+        run: ./sync-hierarchy-mirrors.sh
 
       - name: npm test
         working-directory: ledger-models-javascript

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,116 @@
+name: tests
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  python:
+    name: python (pytest + ruff BLE)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install runtime + test deps
+        working-directory: ledger-models-python
+        run: |
+          python -m pip install --upgrade pip
+          pip install ruff pytest grpcio grpcio-tools protobuf python-dateutil
+
+      - name: ruff check (silent-failure guardrail — BLE001)
+        working-directory: ledger-models-python
+        run: ruff check .
+
+      - name: pytest (unit only)
+        working-directory: ledger-models-python
+        run: python -m pytest -m 'not integration' -x -q
+
+  rust:
+    name: rust (cargo test --lib)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install stable Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - name: cargo test --lib
+        working-directory: ledger-models-rust
+        run: cargo test --lib --quiet
+
+  java:
+    name: java (gradle test)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: gradle test
+        working-directory: ledger-models-java
+        run: ./gradlew test --quiet
+
+  javascript:
+    name: javascript (npm test)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: ledger-models-javascript/package-lock.json
+
+      - name: npm ci
+        working-directory: ledger-models-javascript
+        run: npm ci --ignore-scripts
+
+      - name: npm test
+        working-directory: ledger-models-javascript
+        run: npm test --silent
+
+  ban-broad-except:
+    name: ban-broad-except (cross-language silent-pass scan)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run scan
+        run: bash .github/scripts/ban-broad-except.sh
+
+  downgrade-detector:
+    name: downgrade-detector (fix-upstream-first)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Run downgrade-detector against base branch
+        run: python3 .github/scripts/check-downgrades.py --base "origin/${{ github.base_ref }}"

--- a/ledger-models-javascript/jest.config.js
+++ b/ledger-models-javascript/jest.config.js
@@ -1,4 +1,14 @@
 module.exports = {
     preset: 'ts-jest',
-    testMatch: ["**/*.test.ts"]
+    testMatch: ["**/*.test.ts"],
+    // Exclude service-tier tests that connect to gRPC (price-service,
+    // transaction-service, security-service, position-service,
+    // portfolio-service). They pass locally where services are up
+    // and fail in CI with `UNAVAILABLE: No connection established`.
+    // Run via `npm run test:integration` against a separate config.
+    // See processes/test-discipline.md.
+    testPathIgnorePatterns: [
+      "/node_modules/",
+      "node/wrappers/services/[^/]+/.+\\.test\\.ts$",
+    ],
   };

--- a/ledger-models-javascript/jest.integration.config.js
+++ b/ledger-models-javascript/jest.integration.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+    preset: 'ts-jest',
+    // Only the gRPC-touching service-tier tests. Requires real
+    // services running. See processes/test-discipline.md.
+    testMatch: ["**/node/wrappers/services/*/*.test.ts"],
+  };

--- a/ledger-models-javascript/package.json
+++ b/ledger-models-javascript/package.json
@@ -21,6 +21,7 @@
   "publishConfigNotes": "This package.json does not have a publish config defining the registry because we currently publish to both Github packages & npmjs, so the registry is in the ../.github/workflows/publish.yml files at runtime",
   "scripts": {
     "test": "jest",
+    "test:integration": "jest --config jest.integration.config.js",
     "start": "node index.js"
   },
   "devDependencies": {

--- a/ledger-models-python/fintekkers/wrappers/models/util/date_utils.py
+++ b/ledger-models-python/fintekkers/wrappers/models/util/date_utils.py
@@ -22,10 +22,10 @@ def get_date(input_date:str) -> datetime:
 
     try:
         return datetime.strptime(input_date, '%Y-%m-%d')
-    except:
+    except ValueError:
         try:
             return datetime.strptime(input_date, '%m/%d/%y')
-        except:
+        except ValueError:
             return datetime.strptime(input_date, '%m/%d/%Y')
 
 def get_date_as_dict(input_date:str) -> dict:

--- a/ledger-models-python/fintekkers/wrappers/services/portfolio.py
+++ b/ledger-models-python/fintekkers/wrappers/services/portfolio.py
@@ -1,5 +1,6 @@
 from typing import Generator
 
+from grpc import RpcError
 from google.protobuf.any_pb2 import Any
 from google.protobuf import wrappers_pb2 as wrappers
 
@@ -55,7 +56,7 @@ class PortfolioService:
                     yield Portfolio(portfolio_proto)
         except StopIteration:
             pass
-        except Exception as e:
+        except RpcError as e:
             print(e)
             self.__init__() #Reinitialize the service to reconnect
 

--- a/ledger-models-python/fintekkers/wrappers/services/price.py
+++ b/ledger-models-python/fintekkers/wrappers/services/price.py
@@ -142,7 +142,7 @@ class PriceService:
         # This will send the cancel message to the server to kill the connection
         try:
             responses.cancel()
-        except Exception as e:
+        except RpcError as e:
             print(f"Error cancelling response stream: {e}")
 
     def create_or_update(self, request: CreatePriceRequest):

--- a/ledger-models-python/fintekkers/wrappers/services/security.py
+++ b/ledger-models-python/fintekkers/wrappers/services/security.py
@@ -1,5 +1,7 @@
 from typing import Generator
 from uuid import UUID
+
+from grpc import RpcError
 from fintekkers.models.position.field_pb2 import FieldProto
 from fintekkers.models.util.uuid_pb2 import UUIDProto
 from fintekkers.models.position.position_util_pb2 import FieldMapEntry
@@ -42,7 +44,7 @@ class SecurityService:
                     yield Security(security_proto)
         except StopIteration:
             pass
-        except Exception as e:
+        except RpcError as e:
             print(e)
 
         # This will send the cancel message to the server to kill the connection

--- a/ledger-models-python/fintekkers/wrappers/services/transaction.py
+++ b/ledger-models-python/fintekkers/wrappers/services/transaction.py
@@ -67,7 +67,7 @@ class TransactionService:
         finally:
             try:
                 responses.cancel()
-            except Exception:
+            except RpcError:
                 pass
 
     def create_or_update(self, request: CreateTransactionRequest):

--- a/ledger-models-python/pyproject.toml
+++ b/ledger-models-python/pyproject.toml
@@ -4,3 +4,25 @@ addopts = ["--import-mode=importlib"]
 markers = [
     "integration: marks tests that require running services (deselect with '-m \"not integration\"')",
 ]
+
+# Silent-failure guardrail per second-brain#297. BLE001 forbids
+# `except Exception` and bare `except` in production code paths.
+# See processes/test-discipline.md.
+[tool.ruff]
+# Lint the wrapper / service layer; skip generated proto bindings and
+# tests. Generated files live under fintekkers/models, fintekkers/requests,
+# and end with _pb2.py.
+extend-exclude = [
+    "test", "tests", "venv", ".venv", "build",
+    "fintekkers/models", "fintekkers/requests",
+    "**/*_pb2.py", "**/*_pb2_grpc.py",
+]
+
+[tool.ruff.lint]
+select = ["BLE"]
+
+[tool.ruff.lint.per-file-ignores]
+# link_resolver intentionally uses `except BaseException` to set the
+# future's exception state and re-raise — narrow to BaseException is
+# the deliberate choice here, but ruff still flags it. Reviewed in PRs.
+"fintekkers/wrappers/util/link_resolver.py" = ["BLE"]

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Install the repo's pre-push hook by pointing git at .githooks/.
+# Run once per clone. Idempotent.
+set -euo pipefail
+git config core.hooksPath .githooks
+echo "git core.hooksPath -> .githooks (pre-push will run on next push)"


### PR DESCRIPTION
## Summary

Fan-out reference for **second-brain#288** (test discipline) + **second-brain#297** (silent-failure guardrails) to a multi-language repo. The 7 remaining service repo PRs adapt this template per language.

### What lands

**Hooks (per-clone setup, one command):**
- `scripts/install-hooks.sh` → sets `git config core.hooksPath .githooks`
- `.githooks/pre-push` → detects which sub-projects changed and runs only those test suites; runs all four when proto files change. Sources `ledger-models-python/venv` if present.

**Cross-language scripts:**
- `.github/scripts/check-downgrades.py` — same as ui-service (PR #174). Diffs manifests against base, flags decreasing constraints + new `overrides`/`resolutions`/`[patch.<reg>]`/`[tool.uv.sources]`. Bypass: `DOWNGRADE-EXCEPTION: <rationale> + <upstream-issue-url>` line in PR body.
- `.github/scripts/ban-broad-except.sh` — Python `except: pass` (belt-and-braces vs ruff), Java empty `catch (Exception)`, JS empty `catch`, Rust `.ok();` discard.

**CI workflow** (`.github/workflows/test.yml`) — six jobs:
| Job | What |
|---|---|
| `python` | `ruff check` (BLE001) + `pytest -m 'not integration'` |
| `rust` | `cargo test --lib` |
| `java` | `./gradlew test` |
| `javascript` | `npm ci --ignore-scripts` + `npm test` (jest) |
| `ban-broad-except` | cross-language silent-pass scan |
| `downgrade-detector` | runs only on PR; `fetch-depth: 0` |

**Silent-failure guardrails (#297):**
- `ruff` `BLE001` enabled in `ledger-models-python/pyproject.toml`, scoped to wrapper/service layer (excludes generated `*_pb2.py`).
- 3 pre-existing BLE001 violations fixed in this PR (per the discipline rule that the PR adding the gate owns the failures it exposes):
  - `date_utils.get_date`: bare `except` x2 → `except ValueError` (matches strptime's actual exception)
  - `services/transaction.py:70` cleanup `except Exception` → `RpcError`
  - `services/security.py:45`, `portfolio.py:58`, `price.py:145`: `except Exception as e: print(e)` swallowing in stream-iter cleanup → `RpcError` (matches the existing transaction.py pattern)
- `link_resolver.py` per-file ignore: `except BaseException` is the deliberate choice (sets future exception state and re-raises).

### Out of scope for ledger-models (covered in consumer repo PRs)
- **Per-loader smoke** — no DB loaders in this repo; this guard belongs in `market-data-inputs` / `app-soma-analytics`.
- **Wrapper-only proto-access lint** — this repo IS the wrapper layer; rule excludes ledger-models itself.

### Local verification (per-PR ritual)

- Unit suites green locally:
  - `ledger-models-python`: `pytest -m 'not integration'` → 117 passed, 9 deselected (0.57s)
  - `ledger-models-rust`: `cargo test --lib` → 86 passed (1s)
- `ruff check` → all checks passed (after the 3 fixes above)
- `bash .github/scripts/ban-broad-except.sh` → exit 0
- Synthetic check (Python `_smoke_bad.py` with `except Exception:\n    pass`) → exit 1, file flagged. Removed.
- Pre-push hook fired on `git push -u origin ...`: detected Python changes, ran pytest (117 passed) + ban-broad-except (clean), then released the push.
- `check-downgrades.py` smokes already verified in ui-service PR #174 (same script copied unchanged).

## Test plan
- [x] Local pytest green
- [x] Local cargo test --lib green
- [x] Local ruff clean
- [x] Local ban-broad-except clean (+ deliberate-bad smoke caught)
- [x] Pre-push hook fires correctly on this branch's push
- [ ] CI `python` job green
- [ ] CI `rust` job green
- [ ] CI `java` job green
- [ ] CI `javascript` job green
- [ ] CI `ban-broad-except` job green
- [ ] CI `downgrade-detector` job green

## References
- Issues: https://github.com/FinTekkers/second-brain/issues/288, https://github.com/FinTekkers/second-brain/issues/297
- Reference PRs: https://github.com/FinTekkers/ui-service/pull/172, https://github.com/FinTekkers/ui-service/pull/174
- Discipline doc: `~/second-brain/processes/test-discipline.md`
- Memory rules: `feedback_silent_failure_guardrails`, `feedback_fix_upstream_first`