### PR TITLE
fix(#223): cache gRPC channel via __new__ singleton in Python service wrappers

### DIFF
--- a/ledger-models-python/fintekkers/wrappers/services/portfolio.py
+++ b/ledger-models-python/fintekkers/wrappers/services/portfolio.py
@@ -39,9 +39,39 @@ from fintekkers.wrappers.services.util.Environment import EnvConfig, ServiceType
 
 
 class PortfolioService:
+    # Singleton: see FinTekkers/ledger-models#223. The gRPC channel is
+    # constructed once and reused across all `PortfolioService()` calls
+    # in the process. Tests that need isolation should call
+    # `PortfolioService._reset_for_tests()` between cases.
+    _instance = None
+
+    def __new__(cls):
+        if cls._instance is None:
+            instance = super().__new__(cls)
+            print(
+                "PortfolioService connecting to: "
+                + EnvConfig.api_url(ServiceType.PORTFOLIO_SERVICE)
+            )
+            instance.stub = PortfolioStub(
+                EnvConfig.get_channel(ServiceType.PORTFOLIO_SERVICE)
+            )
+            cls._instance = instance
+        return cls._instance
+
     def __init__(self):
-        print("PortfolioService connecting to: " + EnvConfig.api_url(ServiceType.PORTFOLIO_SERVICE))
-        self.stub = PortfolioStub(EnvConfig.get_channel(ServiceType.PORTFOLIO_SERVICE))
+        pass
+
+    @classmethod
+    def _reset_for_tests(cls) -> None:
+        cls._instance = None
+
+    def _reconnect(self) -> None:
+        """Replace the cached stub with a fresh channel. Called from the
+        search() error path on RpcError. Mutates the singleton in place
+        so existing references continue to work."""
+        self.stub = PortfolioStub(
+            EnvConfig.get_channel(ServiceType.PORTFOLIO_SERVICE)
+        )
 
     def search(
         self, request: QueryPortfolioRequest
@@ -58,7 +88,7 @@ class PortfolioService:
             pass
         except RpcError as e:
             print(e)
-            self.__init__() #Reinitialize the service to reconnect
+            self._reconnect()  # Replace the cached stub with a fresh channel
 
     def create_or_update(
         self, request: CreatePortfolioRequestProto

--- a/ledger-models-python/fintekkers/wrappers/services/price.py
+++ b/ledger-models-python/fintekkers/wrappers/services/price.py
@@ -30,10 +30,32 @@ from fintekkers.wrappers.util.link_resolver import LinkResolver
 from fintekkers.services.price_service.price_service_pb2_grpc import PriceStub
 
 class PriceService:
+    # Singleton: see FinTekkers/ledger-models#223. The gRPC channel is
+    # constructed once and reused across all `PriceService()` calls in
+    # the process. Tests that need isolation should call
+    # `PriceService._reset_for_tests()` between cases.
+    _instance = None
+
+    def __new__(cls):
+        if cls._instance is None:
+            instance = super().__new__(cls)
+            # By default will access the broker.
+            print(
+                "PriceService connecting to: "
+                + EnvConfig.api_url(ServiceType.PRICE_SERVICE)
+            )
+            instance.stub = PriceStub(
+                EnvConfig.get_channel(ServiceType.PRICE_SERVICE)
+            )
+            cls._instance = instance
+        return cls._instance
+
     def __init__(self):
-        #By default will access the broker. 
-        print("PriceService connecting to: " + EnvConfig.api_url(ServiceType.PRICE_SERVICE))
-        self.stub = PriceStub(EnvConfig.get_channel(ServiceType.PRICE_SERVICE))
+        pass
+
+    @classmethod
+    def _reset_for_tests(cls) -> None:
+        cls._instance = None
 
     def get_latest_price(self, identifier: str, identifier_type: IdentifierTypeProto) -> Price:
         raise NotImplementedError("get_latest_price is not yet implemented")

--- a/ledger-models-python/fintekkers/wrappers/services/security.py
+++ b/ledger-models-python/fintekkers/wrappers/services/security.py
@@ -29,9 +29,40 @@ from fintekkers.requests.security.get_field_values_request_pb2 import GetFieldVa
 from fintekkers.wrappers.models.util.serialization import ProtoSerializationUtil
 
 class SecurityService:
+    # Singleton: the gRPC channel underlying `self.stub` is expensive to
+    # construct (TCP / TLS handshake) and is intended to be long-lived and
+    # multiplexed across calls. Consumers instantiate `SecurityService()`
+    # ad-hoc — without caching, that produced a fresh channel per RPC.
+    # See FinTekkers/ledger-models#223.
+    #
+    # Tests that need isolation should call
+    # `SecurityService._reset_for_tests()` between cases.
+    _instance = None
+
+    def __new__(cls):
+        if cls._instance is None:
+            instance = super().__new__(cls)
+            print(
+                "SecurityService connecting to: "
+                + EnvConfig.api_url(ServiceType.SECURITY_SERVICE)
+            )
+            instance.stub = SecurityStub(
+                EnvConfig.get_channel(ServiceType.SECURITY_SERVICE)
+            )
+            cls._instance = instance
+        return cls._instance
+
     def __init__(self):
-        print("SecurityService connecting to: " + EnvConfig.api_url(ServiceType.SECURITY_SERVICE))
-        self.stub = SecurityStub(EnvConfig.get_channel(ServiceType.SECURITY_SERVICE))
+        # Init runs every time `SecurityService()` is called, even when
+        # __new__ returns the cached instance — so all real init lives in
+        # __new__ and __init__ is a no-op to avoid recreating the channel.
+        pass
+
+    @classmethod
+    def _reset_for_tests(cls) -> None:
+        """Drop the cached singleton so the next `SecurityService()` call
+        reconstructs the channel. For test fixtures only."""
+        cls._instance = None
 
     def search(self, request: QuerySecurityRequest) -> Generator[Security, None, None]:
         responses = self.stub.Search(request=request.proto)

--- a/ledger-models-python/fintekkers/wrappers/services/transaction.py
+++ b/ledger-models-python/fintekkers/wrappers/services/transaction.py
@@ -30,18 +30,49 @@ class TransactionService:
 
     Adds `search_with_security_and_portfolio` which composes the search
     with a LinkResolver to hydrate both embedded security and embedded
-    portfolio in parallel-ish (one batched RPC per entity type)."""
+    portfolio in parallel-ish (one batched RPC per entity type).
 
-    def __init__(self, stub: Optional[TransactionStub] = None):
-        if stub is None:
+    Singleton: see FinTekkers/ledger-models#223. The gRPC channel is
+    constructed once and reused across all `TransactionService()` calls
+    in the process. Explicit `stub=` injection (used by unit tests)
+    bypasses the cache and returns a fresh non-cached instance — that
+    keeps the existing test isolation pattern working.
+    """
+
+    _instance: "Optional[TransactionService]" = None
+
+    def __new__(cls, stub: Optional[TransactionStub] = None):
+        # Explicit stub injection (test path): build a fresh, non-cached
+        # instance bound to that stub. Two `TransactionService(stub=m1)` /
+        # `TransactionService(stub=m2)` calls in a test must remain
+        # independent — they're not the singleton.
+        if stub is not None:
+            instance = super().__new__(cls)
+            instance.stub = stub
+            return instance
+        if cls._instance is None:
+            instance = super().__new__(cls)
             print(
                 "TransactionService connecting to: "
                 + EnvConfig.api_url(ServiceType.TRANSACTION_SERVICE)
             )
-            stub = TransactionStub(
+            instance.stub = TransactionStub(
                 EnvConfig.get_channel(ServiceType.TRANSACTION_SERVICE)
             )
-        self.stub = stub
+            cls._instance = instance
+        return cls._instance
+
+    def __init__(self, stub: Optional[TransactionStub] = None):
+        # All init lives in __new__ so the cached singleton is not
+        # re-initialized on subsequent `TransactionService()` calls. The
+        # parameter is preserved so test call sites compile unchanged.
+        pass
+
+    @classmethod
+    def _reset_for_tests(cls) -> None:
+        """Drop the cached singleton so the next `TransactionService()`
+        call reconstructs the channel. For test fixtures only."""
+        cls._instance = None
 
     def search(
         self, request: QueryTransactionRequest

--- a/ledger-models-python/fintekkers/wrappers/services/valuation.py
+++ b/ledger-models-python/fintekkers/wrappers/services/valuation.py
@@ -19,9 +19,31 @@ from fintekkers.wrappers.services.util.Environment import EnvConfig, ServiceType
 
 
 class ValuationService:
+    # Singleton: see FinTekkers/ledger-models#223. The gRPC channel is
+    # constructed once and reused across all `ValuationService()` calls
+    # in the process. Tests that need isolation should call
+    # `ValuationService._reset_for_tests()` between cases.
+    _instance = None
+
+    def __new__(cls):
+        if cls._instance is None:
+            instance = super().__new__(cls)
+            print(
+                "ValuationService connecting to: "
+                + EnvConfig.api_url(ServiceType.VALUATION_SERVICE)
+            )
+            instance.stub = ValuationStub(
+                EnvConfig.get_channel(ServiceType.VALUATION_SERVICE)
+            )
+            cls._instance = instance
+        return cls._instance
+
     def __init__(self):
-        print("ValuationService connecting to: " + EnvConfig.api_url(ServiceType.VALUATION_SERVICE))
-        self.stub = ValuationStub(EnvConfig.get_channel(ServiceType.VALUATION_SERVICE))
+        pass
+
+    @classmethod
+    def _reset_for_tests(cls) -> None:
+        cls._instance = None
 
     def run_valuation(self, 
                      security: Security = None, 

--- a/ledger-models-python/test/wrappers/services/test_singleton_behavior.py
+++ b/ledger-models-python/test/wrappers/services/test_singleton_behavior.py
@@ -1,0 +1,93 @@
+"""Singleton behavior tests for the Python service wrappers.
+
+Per FinTekkers/ledger-models#223, each wrapper caches its gRPC channel
+via a `__new__`-based singleton so consumers that instantiate
+`SecurityService()` per call share a single underlying channel. This file
+verifies that contract: two instantiations return the same object and
+share the same `.stub`; the `_reset_for_tests()` hook restores a fresh
+state.
+
+The Transaction wrapper additionally supports explicit `stub=` injection
+(used by `test_transaction_service.py`) — that path MUST remain
+non-cached so tests that inject distinct mocks stay independent.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from fintekkers.wrappers.services.portfolio import PortfolioService
+from fintekkers.wrappers.services.price import PriceService
+from fintekkers.wrappers.services.security import SecurityService
+from fintekkers.wrappers.services.transaction import TransactionService
+from fintekkers.wrappers.services.valuation import ValuationService
+
+
+@pytest.fixture(autouse=True)
+def _reset_singletons():
+    """Each test sees a fresh singleton state. Without this, ordering
+    between tests in this file (and against any other test that
+    instantiated a service wrapper) would leak."""
+    for cls in (
+        SecurityService,
+        TransactionService,
+        PriceService,
+        PortfolioService,
+        ValuationService,
+    ):
+        cls._reset_for_tests()
+    yield
+    for cls in (
+        SecurityService,
+        TransactionService,
+        PriceService,
+        PortfolioService,
+        ValuationService,
+    ):
+        cls._reset_for_tests()
+
+
+@pytest.mark.parametrize(
+    "cls",
+    [SecurityService, TransactionService, PriceService, PortfolioService, ValuationService],
+)
+def test_two_instantiations_return_same_singleton(cls):
+    a = cls()
+    b = cls()
+    assert a is b, f"{cls.__name__}() must return the cached singleton"
+    assert a.stub is b.stub, f"{cls.__name__} must reuse the same gRPC stub"
+
+
+@pytest.mark.parametrize(
+    "cls",
+    [SecurityService, TransactionService, PriceService, PortfolioService, ValuationService],
+)
+def test_reset_for_tests_drops_cached_instance(cls):
+    first = cls()
+    cls._reset_for_tests()
+    second = cls()
+    assert first is not second, (
+        f"{cls.__name__}._reset_for_tests() must drop the cached singleton"
+    )
+
+
+def test_transaction_service_stub_injection_bypasses_singleton():
+    """The `stub=` escape hatch on TransactionService is used by unit
+    tests that inject mock stubs. Each injection MUST return a fresh,
+    independent instance — not the cached singleton — so that two
+    tests instantiating with different mocks don't share state.
+    """
+    sentinel_a = object()
+    sentinel_b = object()
+
+    svc_a = TransactionService(stub=sentinel_a)  # type: ignore[arg-type]
+    svc_b = TransactionService(stub=sentinel_b)  # type: ignore[arg-type]
+
+    assert svc_a is not svc_b
+    assert svc_a.stub is sentinel_a
+    assert svc_b.stub is sentinel_b
+
+    # And the cached (no-stub) singleton remains untouched.
+    cached = TransactionService()
+    assert cached is not svc_a
+    assert cached is not svc_b


### PR DESCRIPTION
## Summary

Closes #223.

Per the issue, the Python service wrappers (`SecurityService`, `TransactionService`, `PriceService`, `PortfolioService`, `ValuationService`) opened a fresh gRPC channel on every `__init__`, and consumers (`app-soma-analytics`, `market-data-inputs`, etc.) call `SecurityService()` ad-hoc per RPC — so every call paid for a brand-new TCP + TLS handshake. The `TransactionService` had the right consumer pattern (module-level stub) on the caller side but the wrapper itself was equally wrong.

This PR applies the PM-approved `__new__` singleton at the **wrapper layer only**. `EnvConfig.get_channel()` is untouched per PM decision in the issue body.

## Changes

- **All 5 wrappers** (`security.py`, `transaction.py`, `price.py`, `portfolio.py`, `valuation.py`) now cache `_instance` on the class. `__new__` returns the cached instance on subsequent calls; `__init__` is a no-op so the channel isn't rebuilt.
- **`TransactionService`** preserves its `stub=` injection escape hatch — when a stub is explicitly passed (test path), `__new__` returns a fresh non-cached instance. The existing `test_transaction_service.py` cases continue to work unchanged.
- **`PortfolioService.search()`** previously called `self.__init__()` from its `RpcError` handler to reconnect — that's now an explicit `_reconnect()` method that mutates the singleton in place, so existing references remain valid after a reconnect.
- **`_reset_for_tests()`** classmethod on every wrapper drops the cached instance — fixture isolation hook.

## Tests

11 new parametrised cases in `test/wrappers/services/test_singleton_behavior.py`:

| Test                                                                                  | Coverage |
|---|---|
| `test_two_instantiations_return_same_singleton[<service>]`                            | identity + shared stub, ×5 wrappers |
| `test_reset_for_tests_drops_cached_instance[<service>]`                               | reset hook works, ×5 wrappers |
| `test_transaction_service_stub_injection_bypasses_singleton`                          | `stub=` keeps test mocks independent |

Full Python unit suite: **133 passed** (122 prior + 11 new). All existing `test_transaction_service.py` cases still pass — the stub-injection escape hatch is preserved.

```
$ python -m pytest -m "not integration"
====================== 133 passed, 9 deselected in 0.22s =======================
```

## Out of scope

- `EnvConfig.get_channel()` caching (PM decision).
- JS/Java/Rust wrappers (issue scope is Python; other languages have different wrapper shapes and aren't affected by this regression).

## Test plan

- [ ] CI gate (`./compile.sh`) is green
- [ ] Spot-check downstream `app-soma-analytics` smoke (`securities.py:143,362,372` call sites). No code change needed there — every `SecurityService()` now returns the cached channel.
- [ ] DO NOT MERGE — paired with FinTekkers/ledger-service#55 per issue; user merges per `[[feedback_only_user_merges_prs]]`.

## Related

- FinTekkers/ledger-service#55 — server-side JDBC pool bug (paired)
- FinTekkers/second-brain#322 — MBS daily diff/delta reconciliation (parallel; this PR not blocking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)