### PR TITLE
feat(wrappers): Transaction.get_as_of() + Transaction.get_security()

### DIFF
--- a/ledger-models-python/fintekkers/wrappers/models/transaction.py
+++ b/ledger-models-python/fintekkers/wrappers/models/transaction.py
@@ -61,6 +61,23 @@ class Transaction():
         docs/adr/is_link_pattern.md. Pair with LinkResolver to hydrate."""
         return self.proto.is_link
 
+    def get_as_of(self) -> datetime:
+        """Return tx.as_of as a Python datetime. Mirrors Security.get_as_of();
+        callers building link references (e.g. Security.link_of) need the
+        parent transaction's as_of so the resolver hydrates the correct
+        point-in-time vintage."""
+        # Inline import: serialization.py imports TransactionType from this module
+        from fintekkers.wrappers.models.util.serialization import ProtoSerializationUtil
+        return ProtoSerializationUtil.deserialize(self.proto.as_of)
+
+    def get_security(self) -> "Security":
+        """Return tx.security as a wrapped Security. When the returned Security
+        is a link (is_link=true), the caller must resolve via SecurityService
+        before reading non-uuid/as_of fields. See docs/adr/is_link_pattern.md."""
+        # Inline import to avoid pulling the full security module at parse time
+        from fintekkers.wrappers.models.security.security import Security
+        return Security(self.proto.security)
+
 class TransactionType():
     def __init__(self, proto: TransactionTypeProto):
         self.proto = proto

--- a/ledger-models-python/test/models/transaction/test_transaction.py
+++ b/ledger-models-python/test/models/transaction/test_transaction.py
@@ -1,6 +1,44 @@
-# from fintekkers.wrappers.models.transaction import Transaction
+from datetime import datetime
+from uuid import uuid4
 
-# def test_conversion():
-#     Transaction.create_transaction()
-    
-    
+from fintekkers.models.security.security_pb2 import SecurityProto
+from fintekkers.models.util.uuid_pb2 import UUIDProto
+from fintekkers.wrappers.models.security.security import Security
+from fintekkers.wrappers.models.transaction import Transaction
+
+
+def _build_tx(as_of: datetime, security: SecurityProto) -> Transaction:
+    return Transaction.create_from(security=security, as_of=as_of)
+
+
+def test_get_as_of_round_trips_aware_datetime():
+    as_of = datetime(2024, 6, 15, 12, 30, 45)
+    sec = SecurityProto(uuid=UUIDProto(raw_uuid=uuid4().bytes))
+    tx = _build_tx(as_of, sec)
+
+    got = tx.get_as_of()
+
+    assert got.year == 2024 and got.month == 6 and got.day == 15
+    assert got.hour == 12 and got.minute == 30 and got.second == 45
+
+
+def test_get_security_returns_wrapper():
+    sec_uuid = uuid4()
+    sec = SecurityProto(uuid=UUIDProto(raw_uuid=sec_uuid.bytes))
+    tx = _build_tx(datetime.now(), sec)
+
+    wrapped = tx.get_security()
+
+    assert isinstance(wrapped, Security)
+    assert wrapped.get_id() == sec_uuid
+
+
+def test_get_security_preserves_is_link():
+    sec_uuid = uuid4()
+    link = Security.link_of(sec_uuid, datetime.now())
+    tx = _build_tx(datetime.now(), link)
+
+    wrapped = tx.get_security()
+
+    assert wrapped.is_link() is True
+    assert wrapped.get_id() == sec_uuid


### PR DESCRIPTION
## Summary
- Add `Transaction.get_as_of()` -> `datetime` mirroring `Security.get_as_of()`
- Add `Transaction.get_security()` -> `Security` returning a wrapped Security (honors `is_link` semantics)
- Tests covering both methods including the link case

## Why
While running the orphan_repoint recovery (199,191 orphan tx → 194,166 re-pointed at canonical securities via `is_link` form), the script needed `tx.as_of` to construct properly-vintaged link references and `tx.security` as a wrapper for resolution. Both required poking the proto directly because the wrapper API didn't expose them.

These are pure discoverability additions — no behavior change. The strip-to-link mutation pattern is **deliberately not added** here; that lives on the write path (PR #226 strip-on-write) and in the nested-is_link wiring (#340).

## Test plan
- [x] `pytest test/models/transaction/test_transaction.py -v` — 3 passed
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)