### PR TITLE
docs(adr): lazy link hydration plan

### DIFF
--- a/docs/adr/lazy-link-hydration-checklist.md
+++ b/docs/adr/lazy-link-hydration-checklist.md
@@ -94,17 +94,27 @@ The test below proves the wrapper actually hydrates on getter call — without i
   - **When:** caller creates a wrapper from a link proto with `(uuid=X, asOf=T1)` and reads `getProductType()`.
   - **Then:** RPC IS made (`verify(...).getByUuid(X, T1)`); the returned product_type matches the T1-vintage proto (NOT the cached T2 one); user is never silently served the wrong vintage.
 
-- [ ] **C.iii — `linkAsOfIsNull_treatsAnyCachedEntryAsLatest`**
-  - **Given:** cache has uuid `X` at asOf `T2` (whatever vintage). Mock client throws if invoked.
+- [ ] **C.iii — `requestedAsOfNull_withinTtl_hitsCache`**
+  - **Given:** cache has uuid `X` at asOf `T2`, cached 10 seconds ago. TTL_FOR_LATEST = 60s. Mock client throws if invoked.
   - **When:** caller creates a wrapper from a link proto with `(uuid=X, asOf=null)` (no asOf specified, meaning "latest acceptable") and reads `getProductType()`.
-  - **Then:** no RPC; cached entry returned. The asOf-null link is the "I don't care which vintage, give me whatever's cached" semantic.
+  - **Then:** within TTL → no RPC; cached entry returned. **null is the deliberate "latest acceptable" sentinel — documented at the get/set boundaries.**
 
-- [ ] **C.iv — `putOnCache_doesNotEvictNewerVintage`**
+- [ ] **C.iv — `requestedAsOfNull_pastTtl_refetches`**
+  - **Given:** cache has uuid `X` at asOf `T2`, cached 90 seconds ago. TTL = 60s. Mock client returns the current version.
+  - **When:** caller invokes `read(X, asOf=null)`.
+  - **Then:** past TTL → cache miss → service called once. Cache updated with refreshed `cachedAt`. **This closes the cross-process staleness window: a write by another process at 4:05 PM does not stay invisible forever to this process's null-asOf readers — bounded by TTL.**
+
+- [ ] **C.v — `bitemporallyPreciseRead_neverExpiresByTtl`**
+  - **Given:** cache has uuid `X` at asOf `T1`, cached 24 hours ago. Mock client throws if invoked.
+  - **When:** caller invokes `read(X, asOf=T1)` (non-null, exact match to cached vintage).
+  - **Then:** TTL does NOT apply — history doesn't change — cache hit, no RPC.
+
+- [ ] **C.vi — `putOnCache_doesNotEvictNewerVintage`**
   - **Given:** cache has uuid `X` at asOf `T2`.
   - **When:** caller `put`s a proto for uuid `X` at asOf `T1` where `T1 < T2` (older vintage).
   - **Then:** cache entry remains at `T2`; the older `T1` write does not displace the newer cached entry. **(This is the `put` merge logic from the ADR — single-slot semantics with newest-wins on writes.)**
 
-- [ ] **C.v — `putOnCache_overwritesOlderVintage`**
+- [ ] **C.vii — `putOnCache_overwritesOlderVintage`**
   - **Given:** cache has uuid `X` at asOf `T1`.
   - **When:** caller `put`s a proto for uuid `X` at asOf `T2` where `T2 > T1` (newer vintage).
   - **Then:** cache entry is now at `T2`; the older proto is gone.

--- a/docs/adr/lazy-link-hydration-checklist.md
+++ b/docs/adr/lazy-link-hydration-checklist.md
@@ -1,240 +1,149 @@
 # Lazy link hydration — implementation checklist
 
-Companion to [`lazy-link-hydration.md`](lazy-link-hydration.md). One checkbox per concrete action. Update this file as we go — each completed item gets the PR number and date.
+Companion to [`lazy-link-hydration.md`](lazy-link-hydration.md). **5 PRs total** — one per language migration plus one for the ledger-service consumer side. Each PR is large but coherent ("here's how lazy hydration works in <language>"). Tick boxes inside as we go.
 
 ## Phase 0 — Pre-execution
 
 - [ ] ADR PR #230 merged
-- [ ] Tracking issue filed in `FinTekkers/second-brain` titled "Lazy link hydration rollout — Java/Python/TS/Rust" with this checklist's URL in the body
-- [ ] Open the four language follow-up issues, linked to the tracking issue: `lazy-hydrate (java)`, `lazy-hydrate (python)`, `lazy-hydrate (typescript)`, `lazy-hydrate (rust)`. Each is "ready" + `agent:ledger-models-dev`.
+- [ ] Tracking issue filed in `FinTekkers/second-brain` titled "Lazy link hydration rollout" with this checklist's URL in the body. One issue total — not one per language.
 
 ---
 
-## Phase 1 — Java (reference implementation)
+## PR #1 — Java migration (ledger-models)
 
-### Phase 1.A — `LinkCache` class
+Title: `feat(lazy-hydrate): Security/Portfolio/Price/Transaction wrappers + LinkCache + cache write-through (java)`
 
-PR title: `feat(linkcache): latest-only UUID → entity cache for lazy hydration`
+The whole Java story lands in one PR. Reviewer sees the full shape: cache → wrappers → resolver pre-warm → mutation write-through.
 
-- [ ] Branch `feat/linkcache` off `main`
-- [ ] Create `ledger-models-java/src/main/java/common/util/LinkCache.java`
-  - [ ] Generic class `LinkCache<V>` with `ConcurrentMap<UUID, V>` backing
-  - [ ] `static final` singletons: `SECURITY`, `PORTFOLIO`, `PRICE`, `TRANSACTION`
-  - [ ] `get(UUID id)`, `put(UUID id, V value)`, `evict(UUID id)`, `clear()`
-- [ ] Tests at `ledger-models-java/src/test/java/common/util/LinkCacheTest.java`
-  - [ ] `get_returnsNullOnMiss`
-  - [ ] `get_returnsPutValue`
-  - [ ] `put_overwritesPrior`
-  - [ ] `evict_removesEntry`
-  - [ ] `singletons_areIsolated` (writing to SECURITY doesn't affect PORTFOLIO)
-  - [ ] `concurrentPutsAndGets_areThreadSafe` (small concurrent stress test)
-- [ ] `./compile.sh --skip-integration` green
-- [ ] PR opened
-- [ ] PR merged
-- [ ] No release tag yet — `LinkCache` is unused; release after the first consumer
+**LinkCache** — `ledger-models-java/src/main/java/common/util/LinkCache.java`
+- [ ] Generic `LinkCache<V>` with `ConcurrentMap<UUID, V>` backing
+- [ ] `static final` singletons: `SECURITY`, `PORTFOLIO`, `PRICE`, `TRANSACTION`
+- [ ] `get`, `put`, `evict`, `clear`
 
-### Phase 1.B — `Security` wrapper migration
+**Security wrapper** — `common/models/security/Security.java`
+- [ ] Mutable `proto` + `isHydrated` boolean
+- [ ] `proto()` accessor (never fetches)
+- [ ] `getID`, `getAsOf`, `isLink` — link-safe; never hydrate
+- [ ] Every other getter (`getProductType`, `getAssetClass`, `getIssuerName`, `getDescription`, `getIdentifiers`, `getIdentifierByType`, `getBondDetails`, `getMaturityDate`, `getIssueDate`, `getCouponRate`, `getFaceValue`, `getCurrentFactor`, `isCash`, MBS/TIPS/FRN extension getters) routes through `ensureHydrated()`
+- [ ] `ensureHydrated()`: cache check → on miss `SecurityServiceClient.getLatestByUuid(id)` → on null throw `IllegalStateException` with uuid in message → swap `this.proto`, set `isHydrated=true`, populate cache
+- [ ] Delete the `_assert_not_link` / `throwIfLink` guard
 
-PR title: `feat(security): lazy hydrate on first non-link-field access`
-
-- [ ] Branch `feat/security-lazy-hydrate` off latest `main` (which now has LinkCache)
-- [ ] `ledger-models-java/src/main/java/common/models/security/Security.java`
-  - [ ] Add private mutable fields `proto` (the SecurityProto) and `boolean isHydrated`
-  - [ ] Constructor sets `isHydrated = !proto.getIsLink()`
-  - [ ] Add `public SecurityProto proto()` accessor
-  - [ ] Add private `void ensureHydrated()` that: returns early if hydrated; checks `LinkCache.SECURITY`; on miss calls `SecurityServiceClient.singleton().getLatestByUuid(getID())`; on null throws `IllegalStateException` with uuid in message; on success populates cache + swaps `this.proto`
-  - [ ] Route every non-link-safe getter through `ensureHydrated()` (these are: `getProductType`, `getProductTypeProto`, `getAssetClass`, `getIssuerName`, `getDescription`, `getIdentifiers`, `getIdentifierByType`, `getBondDetails`, `getMaturityDate`, `getIssueDate`, `getCouponRate`, `getFaceValue`, `getCurrentFactor`, `isCash`, and the MBS / TIPS / FRN extension getters)
-  - [ ] Leave `getID`, `getAsOf`, `isLink` untouched — they only read `proto.getUuid` / `proto.getAsOf` / `proto.getIsLink` + the `isHydrated` flag
-  - [ ] Delete the `_assert_not_link` / `throwIfLink` guard helper and all references
-- [ ] `ledger-models-java/src/main/java/common/models/security/bonds/*.java` (subclasses): no change needed — they read fields through `Security` accessors which now hydrate themselves
-- [ ] Tests at `ledger-models-java/src/test/java/common/models/security/SecurityLazyHydrateTest.java`
-  - [ ] `getProductType_onHydratedWrapper_returnsField` (no fetch happens)
-  - [ ] `getProductType_onLinkWrapper_hitsCache` (pre-populate cache; assert no RPC)
-  - [ ] `getProductType_onLinkWrapper_fetchesOnMiss` (mock service; assert exactly one RPC)
-  - [ ] `getProductType_resolveFails_throws` (mock service returns null; assert `IllegalStateException`)
-  - [ ] `linkSafeAccessors_doNotHydrate` (call `getID`, `getAsOf`, `isLink` on a link-mode wrapper with no cache + no service; assert no RPC, no exception)
-  - [ ] `isLink_falseAfterHydrate` (link wrapper → trigger hydrate → `isLink()` returns false)
-  - [ ] `secondReadAfterHydrate_doesNotRefetch` (hydrate once; assert one RPC across multiple getter calls)
-  - [ ] `nullProto_throwsAtConstruction` (defensive)
-- [ ] `SecurityServiceClient` — add `getLatestByUuid(UUID)` method if it doesn't exist, with proper failure handling
-- [ ] `./compile.sh --skip-integration` green
-- [ ] PR opened
-- [ ] PR merged
-
-### Phase 1.C — `Portfolio` wrapper migration
-
-PR title: `feat(portfolio): lazy hydrate on first non-link-field access`
-
-- [ ] Branch off latest `main`
-- [ ] `common/models/portfolio/Portfolio.java` — same pattern as Security
-  - [ ] `proto` field + `isHydrated`
-  - [ ] `proto()` accessor
-  - [ ] `ensureHydrated()` → `LinkCache.PORTFOLIO` → `PortfolioServiceClient.getLatestByUuid`
-  - [ ] Route `getPortfolioName` and all other non-uuid/asOf getters
-- [ ] Tests mirror Security suite at `PortfolioLazyHydrateTest.java` (8 cases)
-- [ ] `PortfolioServiceClient.getLatestByUuid` exists / added
-- [ ] `./compile.sh` green
-- [ ] PR opened, merged
-
-### Phase 1.D — `Price` wrapper migration
-
-PR title: `feat(price): lazy hydrate on first non-link-field access`
-
-- [ ] Branch
+**Portfolio, Price, Transaction wrappers** — same shape
+- [ ] `common/models/portfolio/Portfolio.java`
 - [ ] `common/models/price/Price.java`
-  - [ ] Same pattern
-  - [ ] `ensureHydrated()` → `LinkCache.PRICE` → `PriceServiceClient.getLatestByUuid`
-  - [ ] Route `getPrice`, `getSecurity` (returns wrapped Security — itself lazy), and other non-link-safe getters
-- [ ] Tests at `PriceLazyHydrateTest.java`
-- [ ] `PriceServiceClient.getLatestByUuid` exists / added
-- [ ] PR opened, merged
-
-### Phase 1.E — `Transaction` wrapper migration
-
-PR title: `feat(transaction): lazy hydrate on first non-link-field access`
-
-- [ ] Branch
 - [ ] `common/models/transaction/Transaction.java`
-  - [ ] Add `isHydrated` (the proto field already exists from #340)
-  - [ ] `proto()` accessor — replaces the existing `getProto()` if not already present in that form; keep the `getWireProto()` strip path from a future C.4 refactor for now stub it as `getProto()` for compat
-  - [ ] `ensureHydrated()` → `LinkCache.TRANSACTION` → `TransactionServiceClient.getLatestByUuid`
-  - [ ] Route `getTransactionType`, `getQuantity`, `getTradeDate`, `getSettlementDate`, `getTradeName`, `getPositionStatus`, `isCancelled`, `getChildTransactions`, `getStrategyAllocation` through `ensureHydrated()`
-  - [ ] Leave `getID`, `getAsOf`, `isLink`, `getValidFrom`, `getValidTo` untouched
-  - [ ] `getSecurity()` / `getPortfolio()` / `getPrice()` return the wrapped sub-entity — those wrappers handle their own lazy hydration; no `ensureHydrated()` on the Transaction is needed for embedded-link reads
-- [ ] Tests at `TransactionLazyHydrateTest.java`
-  - [ ] `getQuantity_onLinkTransactionWrapper_fetchesViaTransactionService`
-  - [ ] `getSecurity_onLinkTransaction_returnsLazySecurityWrapper` (asserts the returned Security is link-mode; reading product_type on it triggers SecurityService fetch, not TransactionService)
-  - [ ] Plus the standard 8-case suite
-- [ ] `TransactionServiceClient.getLatestByUuid` exists / added
-- [ ] PR opened, merged
+- [ ] For Transaction: `getSecurity()` / `getPortfolio()` / `getPrice()` return wrapped sub-entities (those wrappers self-hydrate); no `ensureHydrated()` on Transaction needed for embedded-link reads
 
-### Phase 1.F — `LinkResolver` writes through to `LinkCache`
+**LinkResolver** — `common/util/LinkResolver.java`
+- [ ] `resolveSecuritiesOnTransactions(txs)`: after batch RPC, populate `LinkCache.SECURITY` (no longer mutates wrapper internals)
+- [ ] Same for portfolios, prices, transactions
+- [ ] Becomes opt-in pre-warm; correctness no longer depends on calling it
 
-PR title: `feat(linkresolver): batch pre-warm populates LinkCache`
-
-- [ ] Branch
-- [ ] `common/util/LinkResolver.java`
-  - [ ] `resolveSecuritiesOnTransactions(txs)`: after the batch `getByIds` RPC, populate `LinkCache.SECURITY.put(id, proto)` for each resolved entity
-  - [ ] `resolvePortfoliosOnTransactions(txs)`: same for `LinkCache.PORTFOLIO`
-  - [ ] Add `resolvePricesOnTransactions(txs)` if it didn't exist; populate `LinkCache.PRICE`
-  - [ ] Add `resolveTransactionsByLink(txs)` for transaction-level link refs; populate `LinkCache.TRANSACTION`
-  - [ ] Stop mutating wrapper internals directly — wrappers handle their own state via `ensureHydrated()` reading from cache
-- [ ] Tests
-  - [ ] `linkResolver_batchPreWarm_populatesCache` (after call, `LinkCache.SECURITY.get(id)` returns the resolved proto)
-  - [ ] `linkResolver_batchPreWarm_subsequentGetterCallsAreCacheHits` (assert no per-getter RPC after batch)
-  - [ ] `linkResolver_emptyInput_noRpc`
-- [ ] PR opened, merged
-
-### Phase 1.G — Service-client write-through on mutation
-
-PR title: `feat(clients): createOrUpdate writes through to LinkCache`
-
-- [ ] Branch
+**Service-client write-through**
 - [ ] `SecurityServiceClient.createOrUpdate`: after RPC, `LinkCache.SECURITY.put(s.getID(), persisted)`
-- [ ] `PortfolioServiceClient.createOrUpdate`: same
-- [ ] `PriceServiceClient.createOrUpdate`: same
-- [ ] `TransactionServiceClient.createOrUpdate`: same
-- [ ] Tests
-  - [ ] `createOrUpdate_writesThroughToCache` (mock service; assert cache.put called with the right id+proto)
-  - [ ] `createOrUpdate_readBackHitsCache` (call createOrUpdate; immediate read of the same entity returns cached value without RPC)
-- [ ] PR opened, merged
+- [ ] Same for Portfolio, Price, Transaction clients
+- [ ] Add `getLatestByUuid(UUID)` to each client if missing
 
-### Phase 1.H — release ledger-models + migrate ledger-service callers
+**Tests** — single test class per wrapper, 8 cases each:
+- [ ] `LinkCacheTest` — get-on-miss, get-after-put, overwrite, evict, singleton isolation, concurrent stress
+- [ ] `SecurityLazyHydrateTest` — getter-on-hydrated-no-fetch, getter-on-link-cache-hit, getter-on-link-fetches-on-miss, resolve-fails-throws, link-safe-accessors-don't-hydrate, isLink-false-after-hydrate, second-read-no-refetch, null-proto-throws
+- [ ] `PortfolioLazyHydrateTest`, `PriceLazyHydrateTest`, `TransactionLazyHydrateTest` — same 8 cases
+- [ ] `LinkResolverWriteThroughTest` — batch resolve populates cache; subsequent getters are cache hits
+- [ ] `ServiceClientWriteThroughTest` (one class covering all 4) — createOrUpdate populates cache; immediate read-back is cache hit
 
-PR title (in ledger-service): `feat: consume ledger-models with lazy hydrate`
-
-- [ ] Tag ledger-models — `./release.sh` to publish next version
-- [ ] Bump ledger-service `subledger/build.gradle` to the new version
-- [ ] Remove explicit `LinkResolver.resolveXOnTransactions(...)` call sites that exist purely to make subsequent reads work — they keep working as pre-warm optimizations, but they're not required for correctness anymore. Audit and remove the ones that are no longer doing useful batching.
-- [ ] Run `./gradlew :subledger:test` — the 5 `Cannot read productType on link-mode Security` failures should now pass
-- [ ] PR opened, merged
-- [ ] Confirm the test suite drops from 25 failures to ≤20
+**Verification**
+- [ ] `./compile.sh --skip-integration` green
+- [ ] PR opened
+- [ ] PR merged
+- [ ] `./release.sh` tags new ledger-models version, publishes to Maven Central + crates.io + PyPI + npm
 
 ---
 
-## Phase 2 — Python
+## PR #2 — ledger-service consumer migration
 
-PR title pattern: `feat(<area>): lazy hydrate on first non-link-field access (python)`
+Title: `feat: consume lazy-hydrate ledger-models; remove redundant explicit hydrate calls`
 
-- [ ] Phase 2.A — `fintekkers/wrappers/util/link_cache.py` + tests
-- [ ] Phase 2.B — `fintekkers/wrappers/models/security/security.py` lazy hydrate + tests
-- [ ] Phase 2.C — `fintekkers/wrappers/models/portfolio.py` (file if missing) lazy hydrate + tests
-- [ ] Phase 2.D — `fintekkers/wrappers/models/price.py` lazy hydrate + tests
-- [ ] Phase 2.E — `fintekkers/wrappers/models/transaction.py` lazy hydrate + tests
-- [ ] Phase 2.F — `fintekkers/wrappers/util/link_resolver.py` writes through to LinkCache + tests
-- [ ] Phase 2.G — `fintekkers/wrappers/services/{security,portfolio,price,transaction}.py`: `create_or_update` writes through + tests
-- [ ] `compile.sh` green (Python unit tests pass)
-- [ ] Release new ledger-models-python wheel to PyPI
-
-For each step:
-- [ ] Behavior tests mirror the Java suite (10 cases per wrapper)
-- [ ] `_assert_not_link(accessor)` calls replaced with `_ensure_hydrated()`
+- [ ] Bump `subledger/build.gradle` to the new ledger-models version
+- [ ] Audit every `LinkResolver.resolveXOnTransactions(...)` call site
+  - [ ] Keep it where it's doing useful batch pre-warming (replay path, large position aggregation)
+  - [ ] Remove it where it was there purely "to make the next read work" — now redundant
+- [ ] Run `./gradlew :subledger:test` — expect the 5 `Cannot read productType on link-mode Security` failures to disappear. The 20 unrelated failures (fixture / treasury-curve / threading) stay.
 - [ ] PR opened, merged
 
 ---
 
-## Phase 3 — TypeScript / JavaScript
+## PR #3 — Python migration (ledger-models-python)
 
-PR title pattern: `feat(<area>): lazy hydrate on first non-link-field access (typescript)`
+Title: `feat(lazy-hydrate): wrappers + LinkCache + cache write-through (python)`
 
-- [ ] Phase 3.A — `node/wrappers/util/LinkCache.ts` + Jest tests
-- [ ] Phase 3.B — `node/wrappers/models/security/Security.ts` + subclasses (`BondSecurity`, `MortgageBackedSecurity`, `FloatingRateNote`, `IndexSecurity`, `TipsBond`) — lazy hydrate via the base `Security` class
-- [ ] Phase 3.C — `node/wrappers/models/portfolio/Portfolio.ts`
-- [ ] Phase 3.D — `node/wrappers/models/price/Price.ts`
-- [ ] Phase 3.E — `node/wrappers/models/transaction/transaction.ts`
-- [ ] Phase 3.F — `node/wrappers/util/link-resolver.ts` writes through to LinkCache
-- [ ] Phase 3.G — `node/wrappers/services/*-service/*Service.ts`: `createOrUpdate` writes through
+Mirrors PR #1's shape in Python idioms.
 
-For each step:
-- [ ] Jest tests mirror the Java suite
+- [ ] `fintekkers/wrappers/util/link_cache.py` — module with process-wide singletons; `dict[UUID, X]` backed; `get`, `put`, `evict`
+- [ ] `fintekkers/wrappers/models/security/security.py` — replace `_assert_not_link(accessor)` calls with `_ensure_hydrated()`; route every non-link-safe getter
+- [ ] `fintekkers/wrappers/models/portfolio.py` (file if missing) — same pattern
+- [ ] `fintekkers/wrappers/models/price.py` — same
+- [ ] `fintekkers/wrappers/models/transaction.py` — same; nested sub-entity getters return their wrappers (those self-hydrate)
+- [ ] `fintekkers/wrappers/util/link_resolver.py` — pre-warm populates `LinkCache`
+- [ ] `fintekkers/wrappers/services/{security,portfolio,price,transaction}.py` — `create_or_update` writes through to cache
+- [ ] Pytest equivalents of the Java test suite (8 cases per wrapper + LinkCache + LinkResolver + client write-through)
+- [ ] `./compile.sh --skip-integration` green (Python unit tests pass)
 - [ ] PR opened, merged
-- [ ] npm package published
+- [ ] PyPI wheel published as part of the next ledger-models release
 
 ---
 
-## Phase 4 — Rust
+## PR #4 — TypeScript migration (ledger-models-javascript)
 
-PR title pattern: `feat(<area>): lazy hydrate on first non-link-field access (rust)`
+Title: `feat(lazy-hydrate): wrappers + LinkCache + cache write-through (typescript)`
 
-The async wrinkle is decided (Shape B — sync + async getter pair). For each component:
-
-- [ ] Phase 4.A — `fintekkers/wrappers/util/link_cache.rs` + `cargo test`
-  - [ ] Module exposes `SECURITY`, `PORTFOLIO`, `PRICE`, `TRANSACTION` static singletons. Choose between `OnceCell` + `RwLock<HashMap<Uuid, Proto>>` vs `dashmap::DashMap` (lean DashMap for read-heavy concurrency).
-  - [ ] Tests: same shape as Java's `LinkCacheTest`
-- [ ] Phase 4.B — `SecurityWrapper`: lazy hydrate
-  - [ ] Replace `assert_not_link(accessor)` panics with cache-and-fetch logic
-  - [ ] Sync getter: returns `Result<_, LinkNotResolved>` — cache hit only
-  - [ ] Async getter (`_async` suffix): does the RPC on miss
-  - [ ] Define `LinkNotResolved { id: Uuid }` and `ResolveError` (network / not-found) error types
-  - [ ] Tests
-- [ ] Phase 4.C — `PortfolioWrapper`: mirror change
-- [ ] Phase 4.D — `PriceWrapper`: mirror change
-- [ ] Phase 4.E — `TransactionWrapper`: mirror change
-- [ ] Phase 4.F — `LinkResolver` writes through to the new `LinkCache`
-  - [ ] Existing `(uuid, as_of)` LRU stays for explicit-vintage path
-  - [ ] New `LinkCache` populated as the latest-only-by-uuid path
-  - [ ] Tests verify both caches are written when LinkResolver runs
-- [ ] Phase 4.G — Service-stub write-through (`tonic`-generated clients wrapped by client structs)
-- [ ] `cargo test` green
-- [ ] Release new ledger-models crate to crates.io
+- [ ] `node/wrappers/util/LinkCache.ts` — Map-based, module-singleton, `SECURITY`/`PORTFOLIO`/`PRICE`/`TRANSACTION` exports
+- [ ] `node/wrappers/models/security/Security.ts` + subclasses (`BondSecurity`, `MortgageBackedSecurity`, `FloatingRateNote`, `IndexSecurity`, `TipsBond`) — lazy hydrate via the base class
+- [ ] `node/wrappers/models/portfolio/Portfolio.ts`
+- [ ] `node/wrappers/models/price/Price.ts`
+- [ ] `node/wrappers/models/transaction/transaction.ts`
+- [ ] `node/wrappers/util/link-resolver.ts` — pre-warm populates `LinkCache`
+- [ ] `node/wrappers/services/*-service/*Service.ts` — `createOrUpdate` write-through
+- [ ] Jest tests mirroring the Java suite
+- [ ] PR opened, merged
+- [ ] npm package published as part of the next ledger-models release
 
 ---
 
-## Phase 5 — Cleanup + ADR follow-ups
+## PR #5 — Rust migration (ledger-models-rust)
 
-- [ ] Delete the (now-unused) `_assert_not_link` / `throwIfLink` / `assert_not_link` guards across all four languages
+Title: `feat(lazy-hydrate): wrappers + LinkCache + cache write-through (rust)`
+
+Uses Shape B from the ADR — sync getters return `Result<_, LinkNotResolved>`; async `_async` variants do the RPC.
+
+- [ ] `fintekkers/wrappers/util/link_cache.rs` — `dashmap::DashMap<Uuid, Proto>` (lean DashMap for read-heavy concurrency); module-level `static` singletons via `OnceCell`
+- [ ] `fintekkers/wrappers/models/security.rs` — replace `assert_not_link(accessor)` panics with cache-or-error; sync getter returns `Result<_, LinkNotResolved>`; async `_async` getter does the RPC on miss
+- [ ] `fintekkers/wrappers/models/portfolio.rs` — same
+- [ ] `fintekkers/wrappers/models/price.rs` — same
+- [ ] `fintekkers/wrappers/models/transaction.rs` — same
+- [ ] `fintekkers/wrappers/util/link_resolver.rs` — populate new `LinkCache` (existing `(uuid, as_of)` LRU stays for explicit-vintage path)
+- [ ] Service-stub write-through on `create_or_update`
+- [ ] `LinkNotResolved { id: Uuid }` and `ResolveError` error types
+- [ ] `cargo test` parity with the Java suite
+- [ ] PR opened, merged
+- [ ] crates.io publication as part of the next ledger-models release
+
+---
+
+## Phase 5 — Cleanup
+
+- [ ] Delete the (now-unused) `_assert_not_link` / `throwIfLink` / `assert_not_link` guards across all four languages (likely already done as part of each PR; verify nothing was missed)
 - [ ] Update [`is_link_pattern.md`](is_link_pattern.md) to point at this ADR for the lazy-vs-explicit-vintage path split
 - [ ] Update [`link_resolver.md`](link_resolver.md) — `LinkResolver` is now opt-in pre-warm, not required
-- [ ] Close the per-language follow-up issues
 - [ ] Close the umbrella tracking issue
 
 ---
 
 ## Notes for during execution
 
-- **One PR per checkbox.** Resist the urge to bundle multiple components into one PR — review cost dominates.
-- **Each PR has a follow-up checkpoint here.** Add the PR number and date in the box (e.g. `[x] ... — #234 (2026-05-30)`).
-- **Branch protection on `main`** (FinTekkers/second-brain#327) means every PR must have green CI before merge. If a PR is red, the next phase doesn't start.
-- **Tests come with the implementation, not after.** A PR without the matching test row above doesn't merge.
-- **Strategy / StrategyAllocation are out of scope** — they have no backing service. Don't add `LinkCache.STRATEGY`.
-- **Consumer call-site audit** (Phase 1.H, and the equivalent step for each downstream language) is where regressions actually disappear. If a callsite was hardcoded to call `LinkResolver` before every read, decide explicitly whether to keep it (still useful as pre-warm batching) or remove it (now redundant).
+- **5 PRs total** (#1 Java, #2 ledger-service consumer, #3 Python, #4 TS, #5 Rust) plus Phase 0/5 housekeeping. Resist further splitting.
+- **PR #1 must land + release before PR #2 can be merged** — ledger-service consumes the new ledger-models version.
+- **PRs #3, #4, #5 are parallel** with each other and with PR #2; each language's release is independent.
+- **Update each box with PR number + date** as we go (e.g. `[x] ... — #237 (2026-05-30)`).
+- **Branch protection on `main`** (FinTekkers/second-brain#327) means every PR needs green CI before merge.
+- **Tests come with the implementation, not after.** Each PR ships its full 8-case wrapper suite.
+- **Strategy / StrategyAllocation are out of scope** — no backing service. Don't add `LinkCache.STRATEGY`.

--- a/docs/adr/lazy-link-hydration-checklist.md
+++ b/docs/adr/lazy-link-hydration-checklist.md
@@ -1,0 +1,240 @@
+# Lazy link hydration — implementation checklist
+
+Companion to [`lazy-link-hydration.md`](lazy-link-hydration.md). One checkbox per concrete action. Update this file as we go — each completed item gets the PR number and date.
+
+## Phase 0 — Pre-execution
+
+- [ ] ADR PR #230 merged
+- [ ] Tracking issue filed in `FinTekkers/second-brain` titled "Lazy link hydration rollout — Java/Python/TS/Rust" with this checklist's URL in the body
+- [ ] Open the four language follow-up issues, linked to the tracking issue: `lazy-hydrate (java)`, `lazy-hydrate (python)`, `lazy-hydrate (typescript)`, `lazy-hydrate (rust)`. Each is "ready" + `agent:ledger-models-dev`.
+
+---
+
+## Phase 1 — Java (reference implementation)
+
+### Phase 1.A — `LinkCache` class
+
+PR title: `feat(linkcache): latest-only UUID → entity cache for lazy hydration`
+
+- [ ] Branch `feat/linkcache` off `main`
+- [ ] Create `ledger-models-java/src/main/java/common/util/LinkCache.java`
+  - [ ] Generic class `LinkCache<V>` with `ConcurrentMap<UUID, V>` backing
+  - [ ] `static final` singletons: `SECURITY`, `PORTFOLIO`, `PRICE`, `TRANSACTION`
+  - [ ] `get(UUID id)`, `put(UUID id, V value)`, `evict(UUID id)`, `clear()`
+- [ ] Tests at `ledger-models-java/src/test/java/common/util/LinkCacheTest.java`
+  - [ ] `get_returnsNullOnMiss`
+  - [ ] `get_returnsPutValue`
+  - [ ] `put_overwritesPrior`
+  - [ ] `evict_removesEntry`
+  - [ ] `singletons_areIsolated` (writing to SECURITY doesn't affect PORTFOLIO)
+  - [ ] `concurrentPutsAndGets_areThreadSafe` (small concurrent stress test)
+- [ ] `./compile.sh --skip-integration` green
+- [ ] PR opened
+- [ ] PR merged
+- [ ] No release tag yet — `LinkCache` is unused; release after the first consumer
+
+### Phase 1.B — `Security` wrapper migration
+
+PR title: `feat(security): lazy hydrate on first non-link-field access`
+
+- [ ] Branch `feat/security-lazy-hydrate` off latest `main` (which now has LinkCache)
+- [ ] `ledger-models-java/src/main/java/common/models/security/Security.java`
+  - [ ] Add private mutable fields `proto` (the SecurityProto) and `boolean isHydrated`
+  - [ ] Constructor sets `isHydrated = !proto.getIsLink()`
+  - [ ] Add `public SecurityProto proto()` accessor
+  - [ ] Add private `void ensureHydrated()` that: returns early if hydrated; checks `LinkCache.SECURITY`; on miss calls `SecurityServiceClient.singleton().getLatestByUuid(getID())`; on null throws `IllegalStateException` with uuid in message; on success populates cache + swaps `this.proto`
+  - [ ] Route every non-link-safe getter through `ensureHydrated()` (these are: `getProductType`, `getProductTypeProto`, `getAssetClass`, `getIssuerName`, `getDescription`, `getIdentifiers`, `getIdentifierByType`, `getBondDetails`, `getMaturityDate`, `getIssueDate`, `getCouponRate`, `getFaceValue`, `getCurrentFactor`, `isCash`, and the MBS / TIPS / FRN extension getters)
+  - [ ] Leave `getID`, `getAsOf`, `isLink` untouched — they only read `proto.getUuid` / `proto.getAsOf` / `proto.getIsLink` + the `isHydrated` flag
+  - [ ] Delete the `_assert_not_link` / `throwIfLink` guard helper and all references
+- [ ] `ledger-models-java/src/main/java/common/models/security/bonds/*.java` (subclasses): no change needed — they read fields through `Security` accessors which now hydrate themselves
+- [ ] Tests at `ledger-models-java/src/test/java/common/models/security/SecurityLazyHydrateTest.java`
+  - [ ] `getProductType_onHydratedWrapper_returnsField` (no fetch happens)
+  - [ ] `getProductType_onLinkWrapper_hitsCache` (pre-populate cache; assert no RPC)
+  - [ ] `getProductType_onLinkWrapper_fetchesOnMiss` (mock service; assert exactly one RPC)
+  - [ ] `getProductType_resolveFails_throws` (mock service returns null; assert `IllegalStateException`)
+  - [ ] `linkSafeAccessors_doNotHydrate` (call `getID`, `getAsOf`, `isLink` on a link-mode wrapper with no cache + no service; assert no RPC, no exception)
+  - [ ] `isLink_falseAfterHydrate` (link wrapper → trigger hydrate → `isLink()` returns false)
+  - [ ] `secondReadAfterHydrate_doesNotRefetch` (hydrate once; assert one RPC across multiple getter calls)
+  - [ ] `nullProto_throwsAtConstruction` (defensive)
+- [ ] `SecurityServiceClient` — add `getLatestByUuid(UUID)` method if it doesn't exist, with proper failure handling
+- [ ] `./compile.sh --skip-integration` green
+- [ ] PR opened
+- [ ] PR merged
+
+### Phase 1.C — `Portfolio` wrapper migration
+
+PR title: `feat(portfolio): lazy hydrate on first non-link-field access`
+
+- [ ] Branch off latest `main`
+- [ ] `common/models/portfolio/Portfolio.java` — same pattern as Security
+  - [ ] `proto` field + `isHydrated`
+  - [ ] `proto()` accessor
+  - [ ] `ensureHydrated()` → `LinkCache.PORTFOLIO` → `PortfolioServiceClient.getLatestByUuid`
+  - [ ] Route `getPortfolioName` and all other non-uuid/asOf getters
+- [ ] Tests mirror Security suite at `PortfolioLazyHydrateTest.java` (8 cases)
+- [ ] `PortfolioServiceClient.getLatestByUuid` exists / added
+- [ ] `./compile.sh` green
+- [ ] PR opened, merged
+
+### Phase 1.D — `Price` wrapper migration
+
+PR title: `feat(price): lazy hydrate on first non-link-field access`
+
+- [ ] Branch
+- [ ] `common/models/price/Price.java`
+  - [ ] Same pattern
+  - [ ] `ensureHydrated()` → `LinkCache.PRICE` → `PriceServiceClient.getLatestByUuid`
+  - [ ] Route `getPrice`, `getSecurity` (returns wrapped Security — itself lazy), and other non-link-safe getters
+- [ ] Tests at `PriceLazyHydrateTest.java`
+- [ ] `PriceServiceClient.getLatestByUuid` exists / added
+- [ ] PR opened, merged
+
+### Phase 1.E — `Transaction` wrapper migration
+
+PR title: `feat(transaction): lazy hydrate on first non-link-field access`
+
+- [ ] Branch
+- [ ] `common/models/transaction/Transaction.java`
+  - [ ] Add `isHydrated` (the proto field already exists from #340)
+  - [ ] `proto()` accessor — replaces the existing `getProto()` if not already present in that form; keep the `getWireProto()` strip path from a future C.4 refactor for now stub it as `getProto()` for compat
+  - [ ] `ensureHydrated()` → `LinkCache.TRANSACTION` → `TransactionServiceClient.getLatestByUuid`
+  - [ ] Route `getTransactionType`, `getQuantity`, `getTradeDate`, `getSettlementDate`, `getTradeName`, `getPositionStatus`, `isCancelled`, `getChildTransactions`, `getStrategyAllocation` through `ensureHydrated()`
+  - [ ] Leave `getID`, `getAsOf`, `isLink`, `getValidFrom`, `getValidTo` untouched
+  - [ ] `getSecurity()` / `getPortfolio()` / `getPrice()` return the wrapped sub-entity — those wrappers handle their own lazy hydration; no `ensureHydrated()` on the Transaction is needed for embedded-link reads
+- [ ] Tests at `TransactionLazyHydrateTest.java`
+  - [ ] `getQuantity_onLinkTransactionWrapper_fetchesViaTransactionService`
+  - [ ] `getSecurity_onLinkTransaction_returnsLazySecurityWrapper` (asserts the returned Security is link-mode; reading product_type on it triggers SecurityService fetch, not TransactionService)
+  - [ ] Plus the standard 8-case suite
+- [ ] `TransactionServiceClient.getLatestByUuid` exists / added
+- [ ] PR opened, merged
+
+### Phase 1.F — `LinkResolver` writes through to `LinkCache`
+
+PR title: `feat(linkresolver): batch pre-warm populates LinkCache`
+
+- [ ] Branch
+- [ ] `common/util/LinkResolver.java`
+  - [ ] `resolveSecuritiesOnTransactions(txs)`: after the batch `getByIds` RPC, populate `LinkCache.SECURITY.put(id, proto)` for each resolved entity
+  - [ ] `resolvePortfoliosOnTransactions(txs)`: same for `LinkCache.PORTFOLIO`
+  - [ ] Add `resolvePricesOnTransactions(txs)` if it didn't exist; populate `LinkCache.PRICE`
+  - [ ] Add `resolveTransactionsByLink(txs)` for transaction-level link refs; populate `LinkCache.TRANSACTION`
+  - [ ] Stop mutating wrapper internals directly — wrappers handle their own state via `ensureHydrated()` reading from cache
+- [ ] Tests
+  - [ ] `linkResolver_batchPreWarm_populatesCache` (after call, `LinkCache.SECURITY.get(id)` returns the resolved proto)
+  - [ ] `linkResolver_batchPreWarm_subsequentGetterCallsAreCacheHits` (assert no per-getter RPC after batch)
+  - [ ] `linkResolver_emptyInput_noRpc`
+- [ ] PR opened, merged
+
+### Phase 1.G — Service-client write-through on mutation
+
+PR title: `feat(clients): createOrUpdate writes through to LinkCache`
+
+- [ ] Branch
+- [ ] `SecurityServiceClient.createOrUpdate`: after RPC, `LinkCache.SECURITY.put(s.getID(), persisted)`
+- [ ] `PortfolioServiceClient.createOrUpdate`: same
+- [ ] `PriceServiceClient.createOrUpdate`: same
+- [ ] `TransactionServiceClient.createOrUpdate`: same
+- [ ] Tests
+  - [ ] `createOrUpdate_writesThroughToCache` (mock service; assert cache.put called with the right id+proto)
+  - [ ] `createOrUpdate_readBackHitsCache` (call createOrUpdate; immediate read of the same entity returns cached value without RPC)
+- [ ] PR opened, merged
+
+### Phase 1.H — release ledger-models + migrate ledger-service callers
+
+PR title (in ledger-service): `feat: consume ledger-models with lazy hydrate`
+
+- [ ] Tag ledger-models — `./release.sh` to publish next version
+- [ ] Bump ledger-service `subledger/build.gradle` to the new version
+- [ ] Remove explicit `LinkResolver.resolveXOnTransactions(...)` call sites that exist purely to make subsequent reads work — they keep working as pre-warm optimizations, but they're not required for correctness anymore. Audit and remove the ones that are no longer doing useful batching.
+- [ ] Run `./gradlew :subledger:test` — the 5 `Cannot read productType on link-mode Security` failures should now pass
+- [ ] PR opened, merged
+- [ ] Confirm the test suite drops from 25 failures to ≤20
+
+---
+
+## Phase 2 — Python
+
+PR title pattern: `feat(<area>): lazy hydrate on first non-link-field access (python)`
+
+- [ ] Phase 2.A — `fintekkers/wrappers/util/link_cache.py` + tests
+- [ ] Phase 2.B — `fintekkers/wrappers/models/security/security.py` lazy hydrate + tests
+- [ ] Phase 2.C — `fintekkers/wrappers/models/portfolio.py` (file if missing) lazy hydrate + tests
+- [ ] Phase 2.D — `fintekkers/wrappers/models/price.py` lazy hydrate + tests
+- [ ] Phase 2.E — `fintekkers/wrappers/models/transaction.py` lazy hydrate + tests
+- [ ] Phase 2.F — `fintekkers/wrappers/util/link_resolver.py` writes through to LinkCache + tests
+- [ ] Phase 2.G — `fintekkers/wrappers/services/{security,portfolio,price,transaction}.py`: `create_or_update` writes through + tests
+- [ ] `compile.sh` green (Python unit tests pass)
+- [ ] Release new ledger-models-python wheel to PyPI
+
+For each step:
+- [ ] Behavior tests mirror the Java suite (10 cases per wrapper)
+- [ ] `_assert_not_link(accessor)` calls replaced with `_ensure_hydrated()`
+- [ ] PR opened, merged
+
+---
+
+## Phase 3 — TypeScript / JavaScript
+
+PR title pattern: `feat(<area>): lazy hydrate on first non-link-field access (typescript)`
+
+- [ ] Phase 3.A — `node/wrappers/util/LinkCache.ts` + Jest tests
+- [ ] Phase 3.B — `node/wrappers/models/security/Security.ts` + subclasses (`BondSecurity`, `MortgageBackedSecurity`, `FloatingRateNote`, `IndexSecurity`, `TipsBond`) — lazy hydrate via the base `Security` class
+- [ ] Phase 3.C — `node/wrappers/models/portfolio/Portfolio.ts`
+- [ ] Phase 3.D — `node/wrappers/models/price/Price.ts`
+- [ ] Phase 3.E — `node/wrappers/models/transaction/transaction.ts`
+- [ ] Phase 3.F — `node/wrappers/util/link-resolver.ts` writes through to LinkCache
+- [ ] Phase 3.G — `node/wrappers/services/*-service/*Service.ts`: `createOrUpdate` writes through
+
+For each step:
+- [ ] Jest tests mirror the Java suite
+- [ ] PR opened, merged
+- [ ] npm package published
+
+---
+
+## Phase 4 — Rust
+
+PR title pattern: `feat(<area>): lazy hydrate on first non-link-field access (rust)`
+
+The async wrinkle is decided (Shape B — sync + async getter pair). For each component:
+
+- [ ] Phase 4.A — `fintekkers/wrappers/util/link_cache.rs` + `cargo test`
+  - [ ] Module exposes `SECURITY`, `PORTFOLIO`, `PRICE`, `TRANSACTION` static singletons. Choose between `OnceCell` + `RwLock<HashMap<Uuid, Proto>>` vs `dashmap::DashMap` (lean DashMap for read-heavy concurrency).
+  - [ ] Tests: same shape as Java's `LinkCacheTest`
+- [ ] Phase 4.B — `SecurityWrapper`: lazy hydrate
+  - [ ] Replace `assert_not_link(accessor)` panics with cache-and-fetch logic
+  - [ ] Sync getter: returns `Result<_, LinkNotResolved>` — cache hit only
+  - [ ] Async getter (`_async` suffix): does the RPC on miss
+  - [ ] Define `LinkNotResolved { id: Uuid }` and `ResolveError` (network / not-found) error types
+  - [ ] Tests
+- [ ] Phase 4.C — `PortfolioWrapper`: mirror change
+- [ ] Phase 4.D — `PriceWrapper`: mirror change
+- [ ] Phase 4.E — `TransactionWrapper`: mirror change
+- [ ] Phase 4.F — `LinkResolver` writes through to the new `LinkCache`
+  - [ ] Existing `(uuid, as_of)` LRU stays for explicit-vintage path
+  - [ ] New `LinkCache` populated as the latest-only-by-uuid path
+  - [ ] Tests verify both caches are written when LinkResolver runs
+- [ ] Phase 4.G — Service-stub write-through (`tonic`-generated clients wrapped by client structs)
+- [ ] `cargo test` green
+- [ ] Release new ledger-models crate to crates.io
+
+---
+
+## Phase 5 — Cleanup + ADR follow-ups
+
+- [ ] Delete the (now-unused) `_assert_not_link` / `throwIfLink` / `assert_not_link` guards across all four languages
+- [ ] Update [`is_link_pattern.md`](is_link_pattern.md) to point at this ADR for the lazy-vs-explicit-vintage path split
+- [ ] Update [`link_resolver.md`](link_resolver.md) — `LinkResolver` is now opt-in pre-warm, not required
+- [ ] Close the per-language follow-up issues
+- [ ] Close the umbrella tracking issue
+
+---
+
+## Notes for during execution
+
+- **One PR per checkbox.** Resist the urge to bundle multiple components into one PR — review cost dominates.
+- **Each PR has a follow-up checkpoint here.** Add the PR number and date in the box (e.g. `[x] ... — #234 (2026-05-30)`).
+- **Branch protection on `main`** (FinTekkers/second-brain#327) means every PR must have green CI before merge. If a PR is red, the next phase doesn't start.
+- **Tests come with the implementation, not after.** A PR without the matching test row above doesn't merge.
+- **Strategy / StrategyAllocation are out of scope** — they have no backing service. Don't add `LinkCache.STRATEGY`.
+- **Consumer call-site audit** (Phase 1.H, and the equivalent step for each downstream language) is where regressions actually disappear. If a callsite was hardcoded to call `LinkResolver` before every read, decide explicitly whether to keep it (still useful as pre-warm batching) or remove it (now redundant).

--- a/docs/adr/lazy-link-hydration-checklist.md
+++ b/docs/adr/lazy-link-hydration-checklist.md
@@ -44,12 +44,115 @@ The whole Java story lands in one PR. Reviewer sees the full shape: cache → wr
 - [ ] Same for Portfolio, Price, Transaction clients
 - [ ] Add `getLatestByUuid(UUID)` to each client if missing
 
-**Tests** — single test class per wrapper, 8 cases each:
-- [ ] `LinkCacheTest` — get-on-miss, get-after-put, overwrite, evict, singleton isolation, concurrent stress
-- [ ] `SecurityLazyHydrateTest` — getter-on-hydrated-no-fetch, getter-on-link-cache-hit, getter-on-link-fetches-on-miss, resolve-fails-throws, link-safe-accessors-don't-hydrate, isLink-false-after-hydrate, second-read-no-refetch, null-proto-throws
-- [ ] `PortfolioLazyHydrateTest`, `PriceLazyHydrateTest`, `TransactionLazyHydrateTest` — same 8 cases
-- [ ] `LinkResolverWriteThroughTest` — batch resolve populates cache; subsequent getters are cache hits
-- [ ] `ServiceClientWriteThroughTest` (one class covering all 4) — createOrUpdate populates cache; immediate read-back is cache hit
+**Tests** — one class per wrapper. Every test is **Given / When / Then** so it documents the behavior, not just the name. Mock the service stub at the boundary; assert on RPC invocation count where relevant.
+
+### A. Hydration is called on each accessor when starting from a link-mode proto
+
+The test below proves the wrapper actually hydrates on getter call — without it, lazy hydration is unverified.
+
+- [ ] **`getProductType_onLinkWrapper_invokesResolverOnce`**
+  - **Given:** a `SecurityWrapper` built from a `SecurityProto` with `is_link=true`, only `uuid` and `asOf` populated. The mock `SecurityServiceClient.getByUuid(uuid, asOf)` is set to return a full SecurityProto. The `LinkCache.SECURITY` is empty.
+  - **When:** caller invokes `wrapper.getProductType()`.
+  - **Then:** the mock service is invoked **exactly once** (verify with `verify(mockClient, times(1)).getByUuid(uuid, asOf)`), and the returned ProductTypeProto matches the resolved proto's product_type.
+
+- [ ] **`everyNonLinkSafeAccessor_invokesResolverOnLinkWrapper`** *(parameterized — one row per accessor)*
+  - **Given:** link-mode SecurityWrapper, empty cache, mock client returns a populated proto on call.
+  - **When:** caller invokes each accessor in turn — `getProductType`, `getAssetClass`, `getIssuerName`, `getDescription`, `getIdentifiers`, `getIdentifierByType(CUSIP)`, `getBondDetails`, `getMaturityDate`, `getIssueDate`, `getCouponRate`, `getFaceValue`, `isCash`, MBS/TIPS/FRN extension getters.
+  - **Then:** the first accessor triggers exactly one RPC (or one cache check then one RPC if cache is empty); each accessor returns the field from the resolved proto.
+
+- [ ] **`linkSafeAccessors_doNotInvokeResolver`**
+  - **Given:** link-mode SecurityWrapper, empty cache, mock client throws if called.
+  - **When:** caller invokes `getID`, `getAsOf`, `isLink`.
+  - **Then:** no RPC is made (`verify(mockClient, never()).getByUuid(any(), any())`); returns are correct (uuid from proto, asOf from proto, isLink=true).
+
+### B. Cache behavior — three explicit sub-tests
+
+- [ ] **B.i — `firstAccessorCall_hydratesAndPopulatesCache`**
+  - **Given:** link-mode SecurityWrapper for uuid `X`, asOf `T`. `LinkCache.SECURITY.get(X, T)` returns null. Mock client returns a full proto.
+  - **When:** caller invokes `wrapper.getProductType()`.
+  - **Then:** (1) mock client is called exactly once with `(X, T)`; (2) `LinkCache.SECURITY.get(X, T)` now returns the full proto; (3) wrapper's internal `isHydrated` is `true`.
+
+- [ ] **B.ii — `secondAccessorCallOnSameWrapper_doesNotInvokeResolverAgain`**
+  - **Given:** the wrapper from B.i, in the state after the first `getProductType()` call. Cache and internal `isHydrated` flag are populated.
+  - **When:** caller invokes `wrapper.getAssetClass()`, then `wrapper.getIssuerName()`, then `wrapper.getProductType()` again.
+  - **Then:** mock client is invoked **zero additional times** (still total of 1 across the whole test). All accessors return the right values from the in-wrapper proto.
+
+- [ ] **B.iii — `subsequentNewWrapper_sameUuidSameAsOf_hitsCache`**
+  - **Given:** the cache is populated for uuid `X` at asOf `T` (e.g., by a prior LinkResolver pre-warm or by a B.i-style first access). The mock client throws if invoked.
+  - **When:** a brand-new `SecurityWrapper(linkProtoFor(X, T))` is constructed and `wrapper.getProductType()` is invoked.
+  - **Then:** no RPC is made; cached proto is used; wrapper's `isHydrated` is `true` after the first accessor call.
+
+### C. asOf semantics — the cache honors the link's asOf
+
+- [ ] **C.i — `linkAsOfMatchesCachedAsOf_isCacheHit`**
+  - **Given:** cache has an entry for uuid `X` whose `proto.asOf == T1`. Mock client throws if invoked.
+  - **When:** caller creates a fresh wrapper from a link proto with `(uuid=X, asOf=T1)` and reads `getProductType()`.
+  - **Then:** no RPC; cached entry returned. **Cache key insight verified: matching asOf → hit.**
+
+- [ ] **C.ii — `linkAsOfDiffersFromCached_forcesRefetch`**
+  - **Given:** cache has uuid `X` at asOf `T2`. Mock client returns a different proto at asOf `T1` when called for `(X, T1)`.
+  - **When:** caller creates a wrapper from a link proto with `(uuid=X, asOf=T1)` and reads `getProductType()`.
+  - **Then:** RPC IS made (`verify(...).getByUuid(X, T1)`); the returned product_type matches the T1-vintage proto (NOT the cached T2 one); user is never silently served the wrong vintage.
+
+- [ ] **C.iii — `linkAsOfIsNull_treatsAnyCachedEntryAsLatest`**
+  - **Given:** cache has uuid `X` at asOf `T2` (whatever vintage). Mock client throws if invoked.
+  - **When:** caller creates a wrapper from a link proto with `(uuid=X, asOf=null)` (no asOf specified, meaning "latest acceptable") and reads `getProductType()`.
+  - **Then:** no RPC; cached entry returned. The asOf-null link is the "I don't care which vintage, give me whatever's cached" semantic.
+
+- [ ] **C.iv — `putOnCache_doesNotEvictNewerVintage`**
+  - **Given:** cache has uuid `X` at asOf `T2`.
+  - **When:** caller `put`s a proto for uuid `X` at asOf `T1` where `T1 < T2` (older vintage).
+  - **Then:** cache entry remains at `T2`; the older `T1` write does not displace the newer cached entry. **(This is the `put` merge logic from the ADR — single-slot semantics with newest-wins on writes.)**
+
+- [ ] **C.v — `putOnCache_overwritesOlderVintage`**
+  - **Given:** cache has uuid `X` at asOf `T1`.
+  - **When:** caller `put`s a proto for uuid `X` at asOf `T2` where `T2 > T1` (newer vintage).
+  - **Then:** cache entry is now at `T2`; the older proto is gone.
+
+### D. Resolve-failure surfaces clearly
+
+- [ ] **D.i — `getProductType_resolveReturnsNull_throwsIllegalStateException`**
+  - **Given:** link-mode wrapper, empty cache, mock client returns null.
+  - **When:** caller invokes `wrapper.getProductType()`.
+  - **Then:** throws `IllegalStateException` whose message contains the uuid in question. No sentinel value is returned.
+
+- [ ] **D.ii — `getProductType_resolveThrows_propagatesException`**
+  - **Given:** link-mode wrapper, empty cache, mock client throws gRPC `UNAVAILABLE`.
+  - **When:** caller invokes `wrapper.getProductType()`.
+  - **Then:** the gRPC exception propagates. The wrapper does not swallow or transform it into a sentinel.
+
+### E. Mutation write-through
+
+- [ ] **E.i — `createOrUpdate_populatesCache`**
+  - **Given:** `LinkCache.SECURITY` does not have uuid `X`. Mock client's `createOrUpdate` returns the persisted proto with asOf `T2`.
+  - **When:** caller invokes `SecurityServiceClient.createOrUpdate(wrapper)`.
+  - **Then:** after the call returns, `LinkCache.SECURITY.get(X, T2)` returns the persisted proto.
+
+- [ ] **E.ii — `readAfterCreateOrUpdate_hitsCache_noExtraRpc`**
+  - **Given:** the state after E.i. Mock client throws on subsequent `getByUuid` calls.
+  - **When:** caller wraps a fresh link proto for `(X, T2)` and reads `getProductType()`.
+  - **Then:** no RPC; cached proto used.
+
+### F. LinkResolver pre-warm
+
+- [ ] **F.i — `resolveSecuritiesOnTransactions_populatesCacheWithBatchEntries`**
+  - **Given:** a `List<Transaction>` with 100 transactions whose security links cover 30 distinct uuid/asOf pairs. Mock client's `getByIds` returns the 30 protos.
+  - **When:** `LinkResolver.resolveSecuritiesOnTransactions(txs)` runs.
+  - **Then:** the mock client is invoked **exactly once** (batch RPC). After the call, `LinkCache.SECURITY.get(...)` returns the resolved proto for each of the 30 keys.
+
+- [ ] **F.ii — `prewarmThenGetter_isCacheHit`**
+  - **Given:** state after F.i. Mock client throws if `getByUuid` is invoked.
+  - **When:** caller reads `txs.get(0).getSecurity().getProductType()`.
+  - **Then:** no per-getter RPC; cached proto used.
+
+### Coverage scope
+
+Each of these test cases is required for **Security**. The test classes for **Portfolio**, **Price**, and **Transaction** repeat the same 16-case suite (A through F) against their respective service mocks and `LinkCache.PORTFOLIO` / `LinkCache.PRICE` / `LinkCache.TRANSACTION`. The transaction test class adds:
+
+- [ ] **G.i — `txGetSecurity_returnsLazySecurityWrapperWhoseGettersIndependentlyHydrate`**
+  - **Given:** a Transaction with a link-mode embedded security (uuid `S`). `LinkCache.TRANSACTION` is empty; `LinkCache.SECURITY` is empty. Mock `TransactionServiceClient` returns a full Transaction proto whose embedded security is itself link-mode (uuid `S`). Mock `SecurityServiceClient` returns a full SecurityProto for `S`.
+  - **When:** caller reads `tx.getSecurity().getProductType()`.
+  - **Then:** TransactionService is called once (to hydrate the Transaction wrapper); SecurityService is called once (to hydrate the embedded Security). Each cache is populated for its respective wrapper.
 
 **Verification**
 - [ ] `./compile.sh --skip-integration` green

--- a/docs/adr/lazy-link-hydration.md
+++ b/docs/adr/lazy-link-hydration.md
@@ -185,25 +185,34 @@ Migration:
 7. `LinkResolver` updated to populate `LinkCache`.
 8. Jest tests.
 
-### Rust (`ledger-models-rust`) — deferred for v1
+### Rust (`ledger-models-rust`)
 
-Today: **No wrapper layer.** Only generated proto structs in `fintekkers.models.*.rs` (via `tonic-build` / `prost-build`). Rust consumers work directly with `SecurityProto { is_link: bool, ... }` — there's no business-logic wrapper to add lazy hydration to.
+Today: Full wrapper ecosystem at `fintekkers/wrappers/models/` — `SecurityWrapper`, `PortfolioWrapper`, `PriceWrapper`, etc. Same pattern as the other languages: `proto` field, `is_link()` boolean, `assert_not_link(accessor)` that **panics** (Rust idiom instead of throwing). A `LinkResolver` at `fintekkers/wrappers/util/link_resolver.rs` already implements bulk hydration with an `(uuid, as_of)` keyed LRU cache + optional TTL — in fact more sophisticated than the current Java implementation.
 
-Decision for v1: **defer.** Rust consumers must explicitly check `proto.is_link` and call SecurityService directly when they need full fields. Document this in `is_link_pattern.md`.
+Migration:
+1. `LinkCache` module: align with the Java pattern. Latest-vintage only, keyed by UUID. The existing `(uuid, as_of)` LRU stays available as the explicit-vintage path's cache (Rust gets to keep what's already there for the time-travel case); the latest-only `LinkCache` is the new path for lazy hydration.
+2. `SecurityWrapper`: replace each `assert_not_link(accessor)` call with `ensure_hydrated()`. Method body cache-check, then call SecurityService via the generated `tonic` stub, then cache-put.
+3. `PortfolioWrapper`, `PriceWrapper`, `TransactionWrapper`: mirror change.
+4. Service-stub write-through on `create_or_update`.
+5. `LinkResolver` updated to populate the latest-only `LinkCache` (in addition to its existing per-vintage cache).
+6. `cargo test` parity with the Java suite.
 
-Future work if Rust consumers grow: add a `wrappers/` module in `ledger-models-rust` that mirrors the Java/Python/TS pattern. Building it requires:
-- A Rust HTTP/gRPC client for SecurityService (`tonic`-generated stub).
-- An async `LinkCache` (`tokio::sync::Mutex<HashMap<Uuid, SecurityProto>>` or a sharded variant).
-- Rust trait-based getters that wrap the proto and gate non-link fields behind `ensure_hydrated()`.
+**The async wrinkle.** Rust is async-first; `ensure_hydrated()` needs an RPC, which is naturally `async`. Three shapes worth picking between (open for review):
 
-Tracking issue: file when a Rust caller hits the pain.
+| Shape | Sync getters? | Cost |
+|---|---|---|
+| **A — `ensure_hydrated()` blocks on the runtime** (`tokio::runtime::Handle::current().block_on(...)`) | Yes | Cannot be called from inside an `async` context that holds the same runtime — would deadlock. Works for sync callers. |
+| **B — Two getter sets**: sync `product_type()` returns `Result<_, LinkNotResolved>` (cache-hit only); async `product_type_async()` does the RPC | Yes (when cache hit) | Two methods per field. Callers must handle the cache-miss `Err`. |
+| **C — Getters return `impl Future`** ; whole wrapper API becomes async | No | Cleanest async story; breaks API parity with the other languages where getters are sync. |
+
+Recommendation: **B** — sync getter returns `Result`, async getter does the RPC. Callers that always pre-warm via `LinkResolver` (the recommended path) use the sync getter and ignore the `Err` case. Callers that want the lazy behavior call the async version. Keeps the wrapper API close to the other languages while respecting Rust's "no hidden blocking" convention.
 
 ## Order of execution
 
 1. **Java first** — biggest pain surface, most active codebase. Establishes the reference behavior + tests. Single PR per wrapper to keep review tractable: PR(LinkCache) → PR(Security) → PR(Portfolio) → PR(Price) → PR(Transaction) → PR(LinkResolver → cache write-through).
 2. **Python second** — parallel migration once Java pattern is stable.
 3. **TypeScript third** — same pattern.
-4. **Rust** — deferred; file a follow-up issue.
+4. **Rust fourth** — same pattern, plus the sync/async getter decision (Shape B above) baked in. Includes deciding what `LinkResolver`'s existing `(uuid, as_of)` LRU keeps doing vs. the new latest-only `LinkCache`.
 
 ## Tests required (per language)
 
@@ -223,10 +232,9 @@ Tracking issue: file when a Rust caller hits the pain.
 ## Out of scope (v1)
 
 - Cross-process cache invalidation (pub/sub or TTL). Future work if eventual-consistency surfaces as a real problem.
-- Async hydration (futures / suspend functions). Current consumers are sync; revisit if a high-throughput async path emerges.
-- Vintage-precise caching. Latest-only cache is by design; vintage queries go through explicit batch resolve.
+- Async hydration in Java/Python/TS (futures / coroutines). Current consumers in those languages are sync; revisit if a high-throughput async path emerges. (Rust is async by construction — see Rust section.)
+- Vintage-precise caching for the latest-only `LinkCache`. Vintage queries go through explicit batch resolve. (Rust keeps its existing `(uuid, as_of)` LRU for that path.)
 - Strategy + StrategyAllocation lazy hydration. No backing service exists; wrapper migration done in PR #229 without is_link.
-- Rust wrapper layer. Deferred entirely.
 
 ## References
 

--- a/docs/adr/lazy-link-hydration.md
+++ b/docs/adr/lazy-link-hydration.md
@@ -83,10 +83,16 @@ public class Security {
 }
 ```
 
-### LinkCache — latest-only, keyed by UUID
+### LinkCache — single-slot per UUID, asOf-validating
+
+The cache stores **one entry per UUID** (memory-bounded), but every hit is **checked against the requested asOf** before returning. This avoids both pitfalls:
+- Storing one entry per `(uuid, asOf)` would let cache memory grow unboundedly across vintage queries.
+- Storing latest-only-by-UUID and ignoring asOf would silently return the wrong vintage on time-travel reads.
+
+`ensureHydrated()` passes both the cached entry's asOf and the requested asOf to a comparator. If the cached entry covers the requested vintage (either it IS the requested vintage, or the request is for "latest" and the cached entry is the latest known), it's a hit. Otherwise refetch from SecurityService at the requested asOf and overwrite the slot.
 
 ```java
-public final class LinkCache<V> {
+public final class LinkCache<V extends HasAsOf> {
     public static final LinkCache<SecurityProto>    SECURITY    = new LinkCache<>();
     public static final LinkCache<PortfolioProto>   PORTFOLIO   = new LinkCache<>();
     public static final LinkCache<TransactionProto> TRANSACTION = new LinkCache<>();
@@ -94,11 +100,35 @@ public final class LinkCache<V> {
 
     private final ConcurrentMap<UUID, V> map = new ConcurrentHashMap<>();
 
-    public V get(UUID id)             { return map.get(id); }
-    public void put(UUID id, V value) { map.put(id, value); }
+    /**
+     * Return cached value if its asOf matches the requested asOf, or
+     * {@code requestedAsOf == null} (treat as "latest acceptable").
+     * Otherwise return null to force a refetch.
+     */
+    public V get(UUID id, ZonedDateTime requestedAsOf) {
+        V cached = map.get(id);
+        if (cached == null) return null;
+        if (requestedAsOf == null) return cached;                  // "latest" — any cached entry is fine
+        if (cached.getAsOf().equals(requestedAsOf)) return cached; // exact vintage hit
+        return null;                                               // vintage mismatch — caller must refetch
+    }
+
+    /** Latest-or-equal write: only overwrite if the new asOf is the
+     *  same as or after the cached one. Older-vintage fetches don't
+     *  evict newer-vintage cached entries. */
+    public void put(UUID id, V value) {
+        map.merge(id, value, (existing, incoming) ->
+            existing.getAsOf().isAfter(incoming.getAsOf()) ? existing : incoming);
+    }
+
     public void evict(UUID id)        { map.remove(id); }
+    public void clear()               { map.clear(); }
 }
 ```
+
+`HasAsOf` is a small interface the generated proto types satisfy via an adapter — `SecurityProto.getAsOf()` returns a `LocalTimestampProto`; we wrap it as `ZonedDateTime`.
+
+The cache is **single-slot per UUID by design**. The "newest seen" entry stays. Vintage-precise queries that touch an older asOf will refetch every time (cache miss), which is correct — vintage queries are a minority code path and should be explicit anyway.
 
 ### Cache update on local mutation
 
@@ -114,16 +144,16 @@ public Security createOrUpdate(Security s) {
 
 Cross-process consistency is best-effort — each process's cache is independent. Acceptable for read-mostly workloads. Future work could add TTL or a pub/sub invalidation path; not required for v1.
 
-### Path split: lazy-latest vs explicit-vintage
+### Path split: lazy honors link's asOf; explicit batch is the perf path
 
-The bitemporal language in `is_link_pattern.md` said: "a link carrying `(uuid, asOf=T)` MUST resolve to the T-vintage." Lazy hydration with a latest-only cache **breaks that for the lazy path**. We accept the split:
+The bitemporal language in `is_link_pattern.md` said: "a link carrying `(uuid, asOf=T)` MUST resolve to the T-vintage." Lazy hydration honors that, by **reading the link's asOf and passing it through to the cache lookup + refetch**:
 
 | Path | Vintage |
 |---|---|
-| Lazy hydration (`security.getProductType()` on a link-mode wrapper) | **Always latest.** Cached. Use for "what is this security TODAY." |
-| Explicit `LinkResolver.resolveSecuritiesAsOf(txs, T)` | **T-vintage.** Bypasses cache. Use for backtests, point-in-time reports, time-travel queries. |
+| Lazy hydration (`security.getProductType()` on a link-mode wrapper) | **The link's asOf vintage.** Cache hit when the most-recently-seen entry matches; refetch otherwise. Never silently returns the wrong vintage. |
+| Explicit `LinkResolver.resolveSecuritiesAsOf(txs, T)` | **T-vintage.** Batch fetch. Use to pre-warm the cache before a known hot loop, or to fetch many vintages at once. |
 
-Most consumers want "latest" (UI, current positions, dispatch by `isCash`/`isBond`). The minority that need historical vintage call the explicit batch resolver and read off the wrappers it populates.
+Most consumers either want "latest" (`link.asOf == null`) or want exactly the vintage carried on the link they were handed; both are honored. The user does **not** need to "use the exact asOf to hit the cache" — they read whatever asOf the link carries, the wrapper does the right thing. Explicit batch resolve exists as a performance optimization, not a correctness requirement.
 
 ### Failure mode
 

--- a/docs/adr/lazy-link-hydration.md
+++ b/docs/adr/lazy-link-hydration.md
@@ -90,6 +90,7 @@ public final class LinkCache<V> {
     public static final LinkCache<SecurityProto>    SECURITY    = new LinkCache<>();
     public static final LinkCache<PortfolioProto>   PORTFOLIO   = new LinkCache<>();
     public static final LinkCache<TransactionProto> TRANSACTION = new LinkCache<>();
+    public static final LinkCache<PriceProto>       PRICE       = new LinkCache<>();
 
     private final ConcurrentMap<UUID, V> map = new ConcurrentHashMap<>();
 
@@ -137,7 +138,7 @@ Most consumers want "latest" (UI, current positions, dispatch by `isCash`/`isBon
 | **Security** | **Yes** | SecurityService | Primary use case. Drives almost all the pain. |
 | **Portfolio** | **Yes** | PortfolioService | Mirror of Security; same pattern. |
 | **Transaction** | **Yes** | TransactionService | Wrapper already proto-backed (#340). Adding hydrate so `tx.getChildTransactions()` etc. work when a Transaction is itself a link reference (rare today, but the proto allows it). |
-| Price | TBD | PriceService | Less acute pain today. Defer until a consumer surfaces. |
+| **Price** | **Yes** | PriceService | Same pattern. `tx.getPrice()` and `tx.getPrice().getSecurity()` are both reachable through link mode; hydrating the embedded Price wrapper closes the same gap that exists for Security and Portfolio. |
 | Strategy / StrategyAllocation | No | none | No service to resolve against (per session 2026-05-28 conversation). Wrapper migration done in PR #229, no is_link. |
 
 ## Per-language implementation plan
@@ -150,10 +151,11 @@ Migration:
 1. `LinkCache` class + tests in `common/util/`.
 2. `Security` wrapper: add `proto()`, `ensureHydrated()`, route every getter through `ensureHydrated()` except `getID()` / `getAsOf()` / `isLink()`. Delete the `_assert_not_link` (`throwIfLink`) guard — hydration replaces it.
 3. `Portfolio` wrapper: mirror change.
-4. `Transaction` wrapper: same pattern. The wrapper is already proto-backed from #340; add `ensureHydrated()` and route the few non-link-safe accessors through it.
-5. `SecurityServiceClient` / `PortfolioServiceClient` / `TransactionServiceClient`: `createOrUpdate` writes through to `LinkCache`.
-6. `LinkResolver.resolveXOnTransactions(...)`: change to write to `LinkCache` instead of (or in addition to) mutating wrapper internals. Becomes the pre-warm path.
-7. Tests: lazy hydrate from cache, lazy hydrate from service on miss, throw on resolve failure, write-through on mutate, batch pre-warm populates cache.
+4. `Price` wrapper: mirror change. Service backing is `PriceService`.
+5. `Transaction` wrapper: same pattern. The wrapper is already proto-backed from #340; add `ensureHydrated()` and route the few non-link-safe accessors through it.
+6. `SecurityServiceClient` / `PortfolioServiceClient` / `PriceServiceClient` / `TransactionServiceClient`: `createOrUpdate` writes through to `LinkCache`.
+7. `LinkResolver.resolveXOnTransactions(...)`: change to write to `LinkCache` instead of (or in addition to) mutating wrapper internals. Becomes the pre-warm path.
+8. Tests: lazy hydrate from cache, lazy hydrate from service on miss, throw on resolve failure, write-through on mutate, batch pre-warm populates cache.
 
 ### Python (`ledger-models-python`)
 
@@ -163,10 +165,11 @@ Migration:
 1. `LinkCache` module at `fintekkers/wrappers/util/link_cache.py` — `dict[UUID, SecurityProto]` etc., process-wide singleton.
 2. `Security` wrapper: replace `_assert_not_link(accessor)` calls with `_ensure_hydrated()`. Method body cache-check, then RPC via the existing `SecurityService` wrapper, then cache-put.
 3. `Portfolio` wrapper: mirror change. (May not exist yet — file if missing.)
-4. `Transaction` wrapper: extend the existing `Transaction(proto)` wrapper with `ensure_hydrated()` plus hydrating accessors for nested security/portfolio. Today the wrapper is thin — `get_security()` returns a wrapped `Security` and the caller hits the link guard if they read non-link fields.
-5. Service-wrapper write-through: `SecurityService.create_or_update` → `LinkCache.SECURITY[id] = resolved`.
-6. `LinkResolver` updated to populate `LinkCache`.
-7. Tests: pytest equivalents of the Java suite.
+4. `Price` wrapper: mirror change.
+5. `Transaction` wrapper: extend the existing `Transaction(proto)` wrapper with `ensure_hydrated()` plus hydrating accessors for nested security/portfolio/price. Today the wrapper is thin — `get_security()` returns a wrapped `Security` and the caller hits the link guard if they read non-link fields.
+6. Service-wrapper write-through: `SecurityService.create_or_update` → `LinkCache.SECURITY[id] = resolved` (and equivalents for Portfolio / Price / Transaction).
+7. `LinkResolver` updated to populate `LinkCache`.
+8. Tests: pytest equivalents of the Java suite.
 
 ### TypeScript / JavaScript (`ledger-models-javascript`)
 
@@ -176,10 +179,11 @@ Migration:
 1. `LinkCache` class at `node/wrappers/util/LinkCache.ts` — Map-based, module-singleton.
 2. `Security.ts` (and `BondSecurity`, `MortgageBackedSecurity`, etc. subclasses): add `ensureHydrated()`. Subclasses' field accessors route through it. The hydrate path uses the existing service stub (`SecurityServiceClient` via `node/wrappers/services/`).
 3. `Portfolio.ts`: mirror.
-4. `Transaction.ts`: mirror.
-5. Service-client write-through.
-6. `LinkResolver` updated to populate `LinkCache`.
-7. Jest tests.
+4. `Price.ts`: mirror.
+5. `Transaction.ts`: mirror.
+6. Service-client write-through (Security / Portfolio / Price / Transaction).
+7. `LinkResolver` updated to populate `LinkCache`.
+8. Jest tests.
 
 ### Rust (`ledger-models-rust`) — deferred for v1
 
@@ -196,7 +200,7 @@ Tracking issue: file when a Rust caller hits the pain.
 
 ## Order of execution
 
-1. **Java first** — biggest pain surface, most active codebase. Establishes the reference behavior + tests. Single PR per wrapper to keep review tractable: PR(LinkCache) → PR(Security) → PR(Portfolio) → PR(Transaction) → PR(LinkResolver → cache write-through).
+1. **Java first** — biggest pain surface, most active codebase. Establishes the reference behavior + tests. Single PR per wrapper to keep review tractable: PR(LinkCache) → PR(Security) → PR(Portfolio) → PR(Price) → PR(Transaction) → PR(LinkResolver → cache write-through).
 2. **Python second** — parallel migration once Java pattern is stable.
 3. **TypeScript third** — same pattern.
 4. **Rust** — deferred; file a follow-up issue.
@@ -221,7 +225,7 @@ Tracking issue: file when a Rust caller hits the pain.
 - Cross-process cache invalidation (pub/sub or TTL). Future work if eventual-consistency surfaces as a real problem.
 - Async hydration (futures / suspend functions). Current consumers are sync; revisit if a high-throughput async path emerges.
 - Vintage-precise caching. Latest-only cache is by design; vintage queries go through explicit batch resolve.
-- Price + Strategy + StrategyAllocation lazy hydration. Price deferred until acute pain. Strategy has no backing service.
+- Strategy + StrategyAllocation lazy hydration. No backing service exists; wrapper migration done in PR #229 without is_link.
 - Rust wrapper layer. Deferred entirely.
 
 ## References

--- a/docs/adr/lazy-link-hydration.md
+++ b/docs/adr/lazy-link-hydration.md
@@ -85,11 +85,11 @@ public class Security {
 
 ### LinkCache — single-slot per UUID, asOf-validating
 
-The cache stores **one entry per UUID** (memory-bounded), but every hit is **checked against the requested asOf** before returning. This avoids both pitfalls:
-- Storing one entry per `(uuid, asOf)` would let cache memory grow unboundedly across vintage queries.
-- Storing latest-only-by-UUID and ignoring asOf would silently return the wrong vintage on time-travel reads.
+The cache stores **one entry per UUID** (memory-bounded), but every hit is **checked against the requested asOf** before returning.
 
-`ensureHydrated()` passes both the cached entry's asOf and the requested asOf to a comparator. If the cached entry covers the requested vintage (either it IS the requested vintage, or the request is for "latest" and the cached entry is the latest known), it's a hit. Otherwise refetch from SecurityService at the requested asOf and overwrite the slot.
+`requestedAsOf` is a `ZonedDateTime` parameter with two meanings:
+- **non-null** → bitemporal-precise: cache hit only when `cached.asOf == requested`. History doesn't change, so no TTL needed.
+- **null** → "latest acceptable": cache hit allowed, but **TTL applies** to bound staleness for cross-process writes that this process didn't observe.
 
 ```java
 public final class LinkCache<V extends HasAsOf> {
@@ -98,37 +98,48 @@ public final class LinkCache<V extends HasAsOf> {
     public static final LinkCache<TransactionProto> TRANSACTION = new LinkCache<>();
     public static final LinkCache<PriceProto>       PRICE       = new LinkCache<>();
 
-    private final ConcurrentMap<UUID, V> map = new ConcurrentHashMap<>();
+    private static final Duration TTL_FOR_LATEST = Duration.ofSeconds(60);
+    private final ConcurrentMap<UUID, CacheEntry<V>> map = new ConcurrentHashMap<>();
 
     /**
-     * Return cached value if its asOf matches the requested asOf, or
-     * {@code requestedAsOf == null} (treat as "latest acceptable").
-     * Otherwise return null to force a refetch.
+     * @param requestedAsOf null = "latest acceptable" (TTL-bounded);
+     *                      non-null = exact-vintage match required.
      */
     public V get(UUID id, ZonedDateTime requestedAsOf) {
-        V cached = map.get(id);
-        if (cached == null) return null;
-        if (requestedAsOf == null) return cached;                  // "latest" — any cached entry is fine
-        if (cached.getAsOf().equals(requestedAsOf)) return cached; // exact vintage hit
-        return null;                                               // vintage mismatch — caller must refetch
+        CacheEntry<V> entry = map.get(id);
+        if (entry == null) return null;
+        if (requestedAsOf == null) {
+            // "Latest" — TTL applies. Past TTL → force refetch.
+            if (Duration.between(entry.cachedAt, Instant.now()).compareTo(TTL_FOR_LATEST) > 0) {
+                return null;
+            }
+            return entry.value;
+        }
+        // Bitemporal-precise — exact match or miss. No TTL (history doesn't change).
+        return entry.value.getAsOf().equals(requestedAsOf) ? entry.value : null;
     }
 
-    /** Latest-or-equal write: only overwrite if the new asOf is the
-     *  same as or after the cached one. Older-vintage fetches don't
-     *  evict newer-vintage cached entries. */
+    /** Newest-wins write: older-vintage writes don't evict newer cached entries. */
     public void put(UUID id, V value) {
-        map.merge(id, value, (existing, incoming) ->
-            existing.getAsOf().isAfter(incoming.getAsOf()) ? existing : incoming);
+        CacheEntry<V> incoming = new CacheEntry<>(value, Instant.now());
+        map.merge(id, incoming, (existing, in) ->
+            existing.value.getAsOf().isAfter(in.value.getAsOf()) ? existing : in);
     }
 
-    public void evict(UUID id)        { map.remove(id); }
-    public void clear()               { map.clear(); }
+    public void evict(UUID id) { map.remove(id); }
+    public void clear()        { map.clear(); }
+
+    private record CacheEntry<V>(V value, Instant cachedAt) {}
 }
 ```
 
 `HasAsOf` is a small interface the generated proto types satisfy via an adapter — `SecurityProto.getAsOf()` returns a `LocalTimestampProto`; we wrap it as `ZonedDateTime`.
 
-The cache is **single-slot per UUID by design**. The "newest seen" entry stays. Vintage-precise queries that touch an older asOf will refetch every time (cache miss), which is correct — vintage queries are a minority code path and should be explicit anyway.
+The cache is **single-slot per UUID by design**. Vintage-precise queries that touch an asOf other than the most-recently-cached entry refetch every time — correct, and vintage queries are a minority code path. `null` requests are TTL-bounded to cap cross-process staleness without infra work.
+
+#### Why not a typed `AsOfSpec` sum type?
+
+Considered (sealed interface with `Latest` singleton + `AtVintage(timestamp)` record), but adds API surface across all four languages and four wrappers. For v1 we accept `null` as a deliberate sentinel meaning "latest acceptable" — documented at the get/set boundaries. If the null overloading becomes a source of bugs in practice, a typed `AsOfSpec` is a clean follow-up that doesn't change the cache mechanics, only the API.
 
 ### Cache update on local mutation
 

--- a/docs/adr/lazy-link-hydration.md
+++ b/docs/adr/lazy-link-hydration.md
@@ -1,0 +1,235 @@
+# ADR: Lazy link hydration
+
+## Status
+
+Proposed. Companion to [`is_link_pattern.md`](is_link_pattern.md) — refines what consumers actually have to do.
+
+## Context
+
+`is_link_pattern.md` established that nested Security / Portfolio / Price / Transaction sub-protos can be stored as link references (`is_link=true`, `uuid` and `as_of` only) and that callers must call `LinkResolver.resolveXOnTransactions(...)` before reading non-link fields. PR #226 (Transaction wrapper) + #338 (Security wrapper) wired this up.
+
+The contract has two acute failure modes today:
+
+1. **Forgetting to hydrate.** Any code path that reads `tx.getSecurity().getProductType()` on a transaction whose embedded Security is link-mode trips `IllegalStateException: Cannot read productType on a link-mode Security`. Every consumer must remember to hydrate; the compiler does not help. The strip-on-write regression that surfaced under FinTekkers/second-brain#327 was exactly this — `TaxLotCalculator._cancelAnyAssociatedCashLots` reads `tx.getCashTransaction().getSecurity().isCash()` without an explicit hydrate step, and the child cash leg's Security was link-mode after strip → `isCash()` returned `false` → NPE downstream.
+
+2. **No defense against silent skip.** A consumer that forgets to hydrate gets either an exception (visible) or the wrong answer from the link-mode fallback (silent). Either is a brittle contract.
+
+## Decision
+
+Wrappers hydrate themselves lazily on first non-link-field access. Calling `security.getProductType()` on a link-mode wrapper transparently:
+
+1. Checks a process-wide `LinkCache` keyed by UUID
+2. On miss, fetches the latest vintage via `SecurityService.getLatestByUuid(id)`
+3. On fetch failure, throws `IllegalStateException` (no sentinel default — surfaces the data lineage break)
+4. Caches the resolved proto; swaps the wrapper's internal proto
+5. Returns the requested field
+
+`LinkResolver.resolveXOnTransactions(...)` continues to exist as an **optional pre-warming batch path** — it populates the `LinkCache` in one RPC for known batches (replay, batch aggregation) so the lazy getter calls hit the cache instead of firing N sequential RPCs. It is **not required** — wrappers work without it; the pre-warm is just a performance optimization.
+
+### Wrapper shape (Java reference)
+
+```java
+public class Security {
+    private SecurityProto proto;          // mutable — replaced on hydrate
+    private boolean isHydrated;
+
+    public Security(SecurityProto proto) {
+        this.proto = proto;
+        this.isHydrated = !proto.getIsLink();
+    }
+
+    /** Current proto, whatever state. Never triggers a fetch. */
+    public SecurityProto proto() { return proto; }
+
+    // Link-safe — uuid + asOf are populated on link-mode by contract.
+    public UUID getID()            { return deserializeUUID(proto.getUuid()); }
+    public ZonedDateTime getAsOf() { return deserializeTimestamp(proto.getAsOf()); }
+    public boolean isLink()        { return proto.getIsLink() && !isHydrated; }
+
+    // Every non-link-safe getter starts with ensureHydrated() — explicit, greppable.
+    public ProductTypeProto getProductType() {
+        ensureHydrated();
+        return proto.getProductType();
+    }
+    public String getIssuerName() {
+        ensureHydrated();
+        return proto.getIssuerName();
+    }
+    public boolean isCash() {
+        ensureHydrated();
+        return Security.fromProto(proto).isCash();
+    }
+    // ... etc for every field other than uuid / asOf
+
+    private void ensureHydrated() {
+        if (isHydrated) return;
+        UUID id = getID();
+        SecurityProto cached = LinkCache.SECURITY.get(id);
+        if (cached != null) {
+            this.proto = cached;
+            this.isHydrated = true;
+            return;
+        }
+        SecurityProto resolved = SecurityServiceClient.singleton().getLatestByUuid(id);
+        if (resolved == null) {
+            throw new IllegalStateException(
+                "Cannot resolve link-mode Security uuid=" + id
+                + " — SecurityService returned no record. Data lineage broken.");
+        }
+        LinkCache.SECURITY.put(id, resolved);
+        this.proto = resolved;
+        this.isHydrated = true;
+    }
+}
+```
+
+### LinkCache — latest-only, keyed by UUID
+
+```java
+public final class LinkCache<V> {
+    public static final LinkCache<SecurityProto>    SECURITY    = new LinkCache<>();
+    public static final LinkCache<PortfolioProto>   PORTFOLIO   = new LinkCache<>();
+    public static final LinkCache<TransactionProto> TRANSACTION = new LinkCache<>();
+
+    private final ConcurrentMap<UUID, V> map = new ConcurrentHashMap<>();
+
+    public V get(UUID id)             { return map.get(id); }
+    public void put(UUID id, V value) { map.put(id, value); }
+    public void evict(UUID id)        { map.remove(id); }
+}
+```
+
+### Cache update on local mutation
+
+Any code path that mutates an entity (`SecurityService.createOrUpdate`, `PortfolioService.createOrUpdate`, etc.) writes through to the cache after the RPC succeeds:
+
+```java
+public Security createOrUpdate(Security s) {
+    SecurityProto persisted = stub.CreateOrUpdate(s.proto());
+    LinkCache.SECURITY.put(s.getID(), persisted);
+    return new Security(persisted);
+}
+```
+
+Cross-process consistency is best-effort — each process's cache is independent. Acceptable for read-mostly workloads. Future work could add TTL or a pub/sub invalidation path; not required for v1.
+
+### Path split: lazy-latest vs explicit-vintage
+
+The bitemporal language in `is_link_pattern.md` said: "a link carrying `(uuid, asOf=T)` MUST resolve to the T-vintage." Lazy hydration with a latest-only cache **breaks that for the lazy path**. We accept the split:
+
+| Path | Vintage |
+|---|---|
+| Lazy hydration (`security.getProductType()` on a link-mode wrapper) | **Always latest.** Cached. Use for "what is this security TODAY." |
+| Explicit `LinkResolver.resolveSecuritiesAsOf(txs, T)` | **T-vintage.** Bypasses cache. Use for backtests, point-in-time reports, time-travel queries. |
+
+Most consumers want "latest" (UI, current positions, dispatch by `isCash`/`isBond`). The minority that need historical vintage call the explicit batch resolver and read off the wrappers it populates.
+
+### Failure mode
+
+- **Resolve fails** (service down, record missing): `IllegalStateException` with `uuid` in the message.
+- **No sentinel defaults.** `null` → throw, missing security → throw.
+- **Cache stale within a process**: best-effort; cross-process write doesn't invalidate. Local mutations do.
+
+## Components to migrate
+
+| Wrapper | Add lazy hydrate? | Service backing it | Notes |
+|---|---|---|---|
+| **Security** | **Yes** | SecurityService | Primary use case. Drives almost all the pain. |
+| **Portfolio** | **Yes** | PortfolioService | Mirror of Security; same pattern. |
+| **Transaction** | **Yes** | TransactionService | Wrapper already proto-backed (#340). Adding hydrate so `tx.getChildTransactions()` etc. work when a Transaction is itself a link reference (rare today, but the proto allows it). |
+| Price | TBD | PriceService | Less acute pain today. Defer until a consumer surfaces. |
+| Strategy / StrategyAllocation | No | none | No service to resolve against (per session 2026-05-28 conversation). Wrapper migration done in PR #229, no is_link. |
+
+## Per-language implementation plan
+
+### Java (`ledger-models-java`) — reference implementation
+
+Today: Wrappers exist for Security, Portfolio, Transaction. `is_link` returns boolean. Non-link-safe getters throw `IllegalStateException`. `LinkResolver` exists as the batch-hydrate path.
+
+Migration:
+1. `LinkCache` class + tests in `common/util/`.
+2. `Security` wrapper: add `proto()`, `ensureHydrated()`, route every getter through `ensureHydrated()` except `getID()` / `getAsOf()` / `isLink()`. Delete the `_assert_not_link` (`throwIfLink`) guard — hydration replaces it.
+3. `Portfolio` wrapper: mirror change.
+4. `Transaction` wrapper: same pattern. The wrapper is already proto-backed from #340; add `ensureHydrated()` and route the few non-link-safe accessors through it.
+5. `SecurityServiceClient` / `PortfolioServiceClient` / `TransactionServiceClient`: `createOrUpdate` writes through to `LinkCache`.
+6. `LinkResolver.resolveXOnTransactions(...)`: change to write to `LinkCache` instead of (or in addition to) mutating wrapper internals. Becomes the pre-warm path.
+7. Tests: lazy hydrate from cache, lazy hydrate from service on miss, throw on resolve failure, write-through on mutate, batch pre-warm populates cache.
+
+### Python (`ledger-models-python`)
+
+Today: Wrapper at `fintekkers/wrappers/models/security/security.py` with `is_link()` boolean and `_assert_not_link(accessor)` that throws `RuntimeError`. `LinkResolver` exists at `fintekkers/wrappers/util/link_resolver.py` as the batch-hydrate path.
+
+Migration:
+1. `LinkCache` module at `fintekkers/wrappers/util/link_cache.py` — `dict[UUID, SecurityProto]` etc., process-wide singleton.
+2. `Security` wrapper: replace `_assert_not_link(accessor)` calls with `_ensure_hydrated()`. Method body cache-check, then RPC via the existing `SecurityService` wrapper, then cache-put.
+3. `Portfolio` wrapper: mirror change. (May not exist yet — file if missing.)
+4. `Transaction` wrapper: extend the existing `Transaction(proto)` wrapper with `ensure_hydrated()` plus hydrating accessors for nested security/portfolio. Today the wrapper is thin — `get_security()` returns a wrapped `Security` and the caller hits the link guard if they read non-link fields.
+5. Service-wrapper write-through: `SecurityService.create_or_update` → `LinkCache.SECURITY[id] = resolved`.
+6. `LinkResolver` updated to populate `LinkCache`.
+7. Tests: pytest equivalents of the Java suite.
+
+### TypeScript / JavaScript (`ledger-models-javascript`)
+
+Today: Wrappers exist for Security, Portfolio, Transaction. `LinkResolver` exists at `node/wrappers/util/link-resolver.ts` with `resolveSecuritiesOnPrices` and similar batch methods. The wrappers throw on non-link-safe field access in link mode (similar to Java).
+
+Migration:
+1. `LinkCache` class at `node/wrappers/util/LinkCache.ts` — Map-based, module-singleton.
+2. `Security.ts` (and `BondSecurity`, `MortgageBackedSecurity`, etc. subclasses): add `ensureHydrated()`. Subclasses' field accessors route through it. The hydrate path uses the existing service stub (`SecurityServiceClient` via `node/wrappers/services/`).
+3. `Portfolio.ts`: mirror.
+4. `Transaction.ts`: mirror.
+5. Service-client write-through.
+6. `LinkResolver` updated to populate `LinkCache`.
+7. Jest tests.
+
+### Rust (`ledger-models-rust`) — deferred for v1
+
+Today: **No wrapper layer.** Only generated proto structs in `fintekkers.models.*.rs` (via `tonic-build` / `prost-build`). Rust consumers work directly with `SecurityProto { is_link: bool, ... }` — there's no business-logic wrapper to add lazy hydration to.
+
+Decision for v1: **defer.** Rust consumers must explicitly check `proto.is_link` and call SecurityService directly when they need full fields. Document this in `is_link_pattern.md`.
+
+Future work if Rust consumers grow: add a `wrappers/` module in `ledger-models-rust` that mirrors the Java/Python/TS pattern. Building it requires:
+- A Rust HTTP/gRPC client for SecurityService (`tonic`-generated stub).
+- An async `LinkCache` (`tokio::sync::Mutex<HashMap<Uuid, SecurityProto>>` or a sharded variant).
+- Rust trait-based getters that wrap the proto and gate non-link fields behind `ensure_hydrated()`.
+
+Tracking issue: file when a Rust caller hits the pain.
+
+## Order of execution
+
+1. **Java first** — biggest pain surface, most active codebase. Establishes the reference behavior + tests. Single PR per wrapper to keep review tractable: PR(LinkCache) → PR(Security) → PR(Portfolio) → PR(Transaction) → PR(LinkResolver → cache write-through).
+2. **Python second** — parallel migration once Java pattern is stable.
+3. **TypeScript third** — same pattern.
+4. **Rust** — deferred; file a follow-up issue.
+
+## Tests required (per language)
+
+| Behavior | Test name |
+|---|---|
+| Hydrated wrapper getter returns field directly (no fetch) | `getProductType_onHydratedWrapper_returnsField` |
+| Link-mode wrapper getter triggers cache hit when populated | `getProductType_onLinkWrapper_hitsCache` |
+| Link-mode wrapper getter triggers RPC fetch on cache miss | `getProductType_onLinkWrapper_fetchesOnMiss` |
+| Resolve failure throws clear exception | `getProductType_resolveFails_throws` |
+| `getID()` / `getAsOf()` do NOT trigger hydration | `linkSafeAccessors_doNotHydrate` |
+| `isLink()` returns false after hydration | `isLink_falseAfterHydrate` |
+| Service-client mutate updates cache | `createOrUpdate_writesThroughToCache` |
+| Batch pre-warm populates cache; subsequent getters skip RPC | `linkResolver_batchPreWarm_subsequentGettersAreCacheHits` |
+| Cache evict invalidates entry | `evict_subsequentGettersFetchAgain` |
+| No sentinel defaults — null input throws | `nullProto_throws` |
+
+## Out of scope (v1)
+
+- Cross-process cache invalidation (pub/sub or TTL). Future work if eventual-consistency surfaces as a real problem.
+- Async hydration (futures / suspend functions). Current consumers are sync; revisit if a high-throughput async path emerges.
+- Vintage-precise caching. Latest-only cache is by design; vintage queries go through explicit batch resolve.
+- Price + Strategy + StrategyAllocation lazy hydration. Price deferred until acute pain. Strategy has no backing service.
+- Rust wrapper layer. Deferred entirely.
+
+## References
+
+- [`is_link_pattern.md`](is_link_pattern.md) — original is_link contract
+- [`link_resolver.md`](link_resolver.md) — current batch-hydrate path
+- PR #338 — Security wrapper
+- PR #340 — Transaction wrapper
+- PR #226 — strip-on-write
+- FinTekkers/second-brain#327 — test gate that surfaced the regression this ADR addresses
+- Session 2026-05-28 — design discussion that produced this ADR

--- a/docs/adr/lazy-link-hydration.md
+++ b/docs/adr/lazy-link-hydration.md
@@ -197,15 +197,34 @@ Migration:
 5. `LinkResolver` updated to populate the latest-only `LinkCache` (in addition to its existing per-vintage cache).
 6. `cargo test` parity with the Java suite.
 
-**The async wrinkle.** Rust is async-first; `ensure_hydrated()` needs an RPC, which is naturally `async`. Three shapes worth picking between (open for review):
+**The async wrinkle — decision: two-getter pattern.** Rust is async-first; `ensure_hydrated()` needs an RPC, which is naturally `async`. Each non-link-safe field exposes both a sync and an async accessor:
 
-| Shape | Sync getters? | Cost |
-|---|---|---|
-| **A — `ensure_hydrated()` blocks on the runtime** (`tokio::runtime::Handle::current().block_on(...)`) | Yes | Cannot be called from inside an `async` context that holds the same runtime — would deadlock. Works for sync callers. |
-| **B — Two getter sets**: sync `product_type()` returns `Result<_, LinkNotResolved>` (cache-hit only); async `product_type_async()` does the RPC | Yes (when cache hit) | Two methods per field. Callers must handle the cache-miss `Err`. |
-| **C — Getters return `impl Future`** ; whole wrapper API becomes async | No | Cleanest async story; breaks API parity with the other languages where getters are sync. |
+```rust
+impl SecurityWrapper {
+    // Sync — cache-hit only. Returns Err if the link hasn't been resolved.
+    // Use this when the call site is pre-warming via LinkResolver (the
+    // recommended path).
+    pub fn product_type(&self) -> Result<ProductTypeProto, LinkNotResolved> {
+        let cached = self.try_from_cache_or_proto();
+        cached.ok_or(LinkNotResolved { id: self.uuid_wrapper().to_uuid() })
+            .map(|p| ProductTypeProto::try_from(p.product_type).unwrap())
+    }
 
-Recommendation: **B** — sync getter returns `Result`, async getter does the RPC. Callers that always pre-warm via `LinkResolver` (the recommended path) use the sync getter and ignore the `Err` case. Callers that want the lazy behavior call the async version. Keeps the wrapper API close to the other languages while respecting Rust's "no hidden blocking" convention.
+    // Async — does the RPC on cache miss. Use when the call site can't
+    // batch up front and needs lazy semantics.
+    pub async fn product_type_async(&self) -> Result<ProductTypeProto, ResolveError> {
+        self.ensure_hydrated().await?;
+        Ok(ProductTypeProto::try_from(self.proto.product_type).unwrap())
+    }
+}
+```
+
+Rejected alternatives:
+
+- **`block_on` inside a single sync getter** — deadlocks if called from inside the same tokio runtime. Subtle, dangerous, doesn't fit Rust's "no hidden blocking" convention.
+- **All getters return `impl Future`** — cleanest async story, but breaks API parity with the other languages and makes simple consumers (logging a CUSIP, comparing two securities by id) needlessly awkward.
+
+The two-getter pattern keeps the wrapper API close to Java / Python / TypeScript for the common case (pre-warm + sync access), provides a clean lazy escape hatch via the `_async` variant, and never blocks the runtime.
 
 ## Order of execution
 


### PR DESCRIPTION
## Summary
ADR capturing the design agreed in our 2026-05-28 session before we start migrating Security / Portfolio / Transaction wrappers to lazy-hydrate on first non-link-field access. Land this first so all four languages converge on the same shape and we don't drift mid-execution.

## What's in the doc

- The contract: lazy-hydrate on getter call (not eager hydrate), with the existing `LinkResolver` repurposed as optional batch pre-warm
- Wrapper shape (Java reference): `proto()` accessor + `ensureHydrated()` called from each non-link-safe getter, explicit and greppable
- `LinkCache` keyed by UUID with latest-vintage only
- Cache write-through on local mutation
- Lazy-latest vs explicit-vintage path split (preserves bitemporal correctness for time-travel queries while letting hot paths get latest from cache)
- No sentinel defaults — resolve failure throws, surfaces data lineage breaks
- Per-language plan: Java first (reference); Python + TypeScript parallel; Rust deferred (no wrapper layer exists yet)
- Components: **Security, Portfolio, Transaction** all migrate. Price deferred. Strategy stays as-is (no backing service).

## Why this PR is just docs
We've shipped enough partial migrations this week (#338, #340, #226, #229) to make me want a written spec before the next round. Drift between Java and Python on `is_link` semantics is exactly what produced the strip-on-write regression that took us through #327 today. Locking the design in this ADR first.

## Test plan
- [x] ADR explains every decision discussed
- [ ] Reviewer agrees (or pushes back) on the four open trade-offs called out in the doc (cross-process consistency, async, vintage caching, Rust deferral)
- [ ] After merge, file follow-up issues per language migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)