### PR TITLE
docs(adr): add LinkResolver LRU → LinkCache consolidation follow-up

### DIFF
--- a/docs/adr/lazy-link-hydration-checklist.md
+++ b/docs/adr/lazy-link-hydration-checklist.md
@@ -27,6 +27,7 @@ Companion to [`lazy-link-hydration.md`](lazy-link-hydration.md). **5 PRs total**
 | follow-up | Rust two-getter Shape B (sync `Result` + async `_async` variant) | pending — captured in ADR §"async wrinkle" |
 | follow-up | Rust Portfolio + Price + Transaction wrappers | pending |
 | follow-up | Rust LinkResolver write-through + service-stub write-through | pending |
+| follow-up | **Collapse LinkResolver internal LRU → LinkCache** (all 4 langs). Post-#237 write-through, the resolver's per-instance LRU stores the same protos as the process-wide LinkCache and is GC'd at the end of most service-wrapper calls (callers rarely thread a shared resolver across calls). Route the resolver's "have we already fetched?" check through `LinkCache.get(uuid, as_of)`, delete the `_TinyLRU` + `cache_size` / `ttl_ms` ctor params, and give `LinkCache` an LRU-with-cap option (per-entity TTLs already noted: Portfolio ~1d, Security ~1d, Transaction ~1m, Price ~30s). Net effect: one cache, one TTL story, one source of truth. Removes the asymmetry where #240's `isCash()` ensure-hydrate reads LinkCache but the resolver writes (and reads) the LRU first. | pending |
 
 **Cross-language scope audit (2026-05-28)**
 


### PR DESCRIPTION
Adds one row to the live-progress table on the lazy-link-hydration checklist.

## Why

Post-#237 the resolver's per-instance \`_TinyLRU\` stores the same protos as the process-wide \`LinkCache\`. In the common path (caller of \`search_with_securities\` / \`search_with_security_and_portfolio\` doesn't thread a shared resolver across calls) the LRU lives one function call and is GC'd at function exit; the LinkCache absorbs the writes and serves all subsequent accessor reads.

The LRU is only doing actual work in two narrow cases:
1. A **shared resolver** is threaded across multiple wrapper-service calls in the same request scope (rare).
2. Inside a **single** \`resolve_securities(items)\` call when items reference the same uuid many times — but the resolver already pre-deduplicates into bucket dicts before issuing any RPC, so the LRU isn't carrying the dedup.

The single thing the LRU still provides that LinkCache doesn't: a **bound on memory**. LinkCache is currently unbounded.

## The proposed cleanup

Route the resolver's "have we already fetched?" check through \`LinkCache.get(uuid, as_of)\`, delete the \`_TinyLRU\` + \`cache_size\` / \`ttl_ms\` ctor params, and give \`LinkCache\` an LRU-with-cap option (per-entity TTLs already noted: Portfolio ~1d, Security ~1d, Transaction ~1m, Price ~30s).

Net effect: one cache, one TTL story, one source of truth. Removes the asymmetry where #240's \`isCash()\` ensure-hydrate reads LinkCache but the resolver writes (and reads) the LRU first.

Scope: all 4 languages. Docs-only PR — implementation is the follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)