### PR TITLE
fix(#348): hydrate Security/Portfolio on child_transactions recursively

### DIFF
--- a/ledger-models-java/src/main/java/common/util/LinkResolver.java
+++ b/ledger-models-java/src/main/java/common/util/LinkResolver.java
@@ -211,58 +211,198 @@ public class LinkResolver {
         return out;
     }
 
-    /** Same shape as resolveSecuritiesOnPrices, for embedded security on Transaction. */
+    /**
+     * Hydrate the embedded security on each Transaction <b>and on every
+     * descendant {@code child_transactions[i].security}</b>, recursively.
+     *
+     * <p>Children carry their own {@code security} sub-proto. After
+     * {@code Transaction.getProto()} applies strip-on-write (Phase 2 #340)
+     * <em>every</em> nested security in the tree is rewritten to a link
+     * reference — top-level, the BUY's cash-impact WITHDRAWAL leg, the
+     * derived MATURATION, the MATURATION's DEPOSIT leg, all of it. The
+     * previous top-level-only resolver missed children, so a consumer
+     * reading {@code child.getSecurity()} got
+     * {@code Security.fromProto(linkProto)} → base {@code Security}, which
+     * blew up downstream casts (e.g. {@code TaxLotCalculator.java:61}'s
+     * {@code (BondSecurity) txn.getSecurity()} on the MATURATION child —
+     * second-brain#348).
+     *
+     * <p>Two-phase implementation: first walk the whole forest (top-level +
+     * every child) collecting link-mode SecurityProto sub-messages, bucket
+     * by {@code as_of} and fire one batched {@code GetByIds} per bucket
+     * (same dedup contract as the top-level path); then rewrite each
+     * Transaction recursively, swapping in the resolved proto wherever a
+     * link was previously sitting. Wrappers whose embedded security is
+     * already a full proto pass through unchanged.
+     */
     public List<TransactionProto> resolveSecuritiesOnTransactions(List<TransactionProto> txns) {
-        ensureSecuritiesCached(txns, TransactionProto::hasSecurity, TransactionProto::getSecurity);
+        // Phase 1: cache-warm every link-mode security in the forest.
+        List<SecurityProto> allSecurityLinks = new ArrayList<>();
+        for (TransactionProto t : txns) {
+            collectLinkSecurities(t, allSecurityLinks);
+        }
+        ensureSecurityLinksCached(allSecurityLinks);
+
+        // Phase 2: rebuild each tree, swapping link-mode → resolved.
         List<TransactionProto> out = new ArrayList<>(txns.size());
         for (TransactionProto t : txns) {
-            if (!t.hasSecurity() || !t.getSecurity().getIsLink()) {
-                out.add(t);
-                continue;
-            }
-            SecurityProto resolved = lookupResolvedSecurity(t.getSecurity());
-            if (resolved == null) {
-                out.add(t);
-            } else {
-                out.add(t.toBuilder().setSecurity(resolved).build());
-            }
+            out.add(rewriteSecuritiesRecursive(t));
         }
         return out;
     }
 
-    /** Hydrate the embedded portfolio on each Transaction. */
+    /**
+     * Hydrate the embedded portfolio on each Transaction <b>and on every
+     * descendant {@code child_transactions[i].portfolio}</b>, recursively.
+     * Same shape and rationale as
+     * {@link #resolveSecuritiesOnTransactions(List)}; the cash-leg and
+     * MATURATION children all carry their own portfolio sub-proto and the
+     * strip-on-write pass turns them all into links.
+     */
     public List<TransactionProto> resolvePortfoliosOnTransactions(List<TransactionProto> txns) {
-        ensurePortfoliosCached(txns);
+        List<PortfolioProto> allPortfolioLinks = new ArrayList<>();
+        for (TransactionProto t : txns) {
+            collectLinkPortfolios(t, allPortfolioLinks);
+        }
+        ensurePortfolioLinksCached(allPortfolioLinks);
+
         List<TransactionProto> out = new ArrayList<>(txns.size());
         for (TransactionProto t : txns) {
-            if (!t.hasPortfolio() || !t.getPortfolio().getIsLink()) {
-                out.add(t);
-                continue;
-            }
-            PortfolioProto resolved = lookupResolvedPortfolio(t.getPortfolio());
-            if (resolved == null) {
-                out.add(t);
-            } else {
-                out.add(t.toBuilder().setPortfolio(resolved).build());
-            }
+            out.add(rewritePortfoliosRecursive(t));
         }
         return out;
+    }
+
+    // ---------- recursion helpers (second-brain#348) ----------
+
+    private static void collectLinkSecurities(TransactionProto t, List<SecurityProto> sink) {
+        if (t.hasSecurity() && t.getSecurity().getIsLink()) {
+            sink.add(t.getSecurity());
+        }
+        for (TransactionProto child : t.getChildTransactionsList()) {
+            collectLinkSecurities(child, sink);
+        }
+    }
+
+    private static void collectLinkPortfolios(TransactionProto t, List<PortfolioProto> sink) {
+        if (t.hasPortfolio() && t.getPortfolio().getIsLink()) {
+            sink.add(t.getPortfolio());
+        }
+        for (TransactionProto child : t.getChildTransactionsList()) {
+            collectLinkPortfolios(child, sink);
+        }
+    }
+
+    /**
+     * Returns a TransactionProto with every link-mode {@code security}
+     * (top-level + every descendant) swapped for the resolved version
+     * sitting in {@link LinkCache#SECURITY}. Returns the input unchanged
+     * (reference-equal) if nothing in the tree needed rewriting — lets the
+     * caller's per-element identity check work.
+     */
+    private TransactionProto rewriteSecuritiesRecursive(TransactionProto t) {
+        boolean anyChildRewritten = false;
+        List<TransactionProto> rewrittenChildren = null;
+        for (int i = 0; i < t.getChildTransactionsCount(); i++) {
+            TransactionProto child = t.getChildTransactions(i);
+            TransactionProto newChild = rewriteSecuritiesRecursive(child);
+            if (newChild != child) {
+                if (rewrittenChildren == null) {
+                    rewrittenChildren = new ArrayList<>(t.getChildTransactionsList());
+                }
+                rewrittenChildren.set(i, newChild);
+                anyChildRewritten = true;
+            }
+        }
+
+        SecurityProto resolvedTop = null;
+        if (t.hasSecurity() && t.getSecurity().getIsLink()) {
+            resolvedTop = lookupResolvedSecurity(t.getSecurity());
+        }
+
+        if (resolvedTop == null && !anyChildRewritten) {
+            return t;
+        }
+
+        TransactionProto.Builder b = t.toBuilder();
+        if (resolvedTop != null) {
+            b.setSecurity(resolvedTop);
+        }
+        if (anyChildRewritten) {
+            b.clearChildTransactions();
+            for (TransactionProto c : rewrittenChildren) {
+                b.addChildTransactions(c);
+            }
+        }
+        return b.build();
+    }
+
+    private TransactionProto rewritePortfoliosRecursive(TransactionProto t) {
+        boolean anyChildRewritten = false;
+        List<TransactionProto> rewrittenChildren = null;
+        for (int i = 0; i < t.getChildTransactionsCount(); i++) {
+            TransactionProto child = t.getChildTransactions(i);
+            TransactionProto newChild = rewritePortfoliosRecursive(child);
+            if (newChild != child) {
+                if (rewrittenChildren == null) {
+                    rewrittenChildren = new ArrayList<>(t.getChildTransactionsList());
+                }
+                rewrittenChildren.set(i, newChild);
+                anyChildRewritten = true;
+            }
+        }
+
+        PortfolioProto resolvedTop = null;
+        if (t.hasPortfolio() && t.getPortfolio().getIsLink()) {
+            resolvedTop = lookupResolvedPortfolio(t.getPortfolio());
+        }
+
+        if (resolvedTop == null && !anyChildRewritten) {
+            return t;
+        }
+
+        TransactionProto.Builder b = t.toBuilder();
+        if (resolvedTop != null) {
+            b.setPortfolio(resolvedTop);
+        }
+        if (anyChildRewritten) {
+            b.clearChildTransactions();
+            for (TransactionProto c : rewrittenChildren) {
+                b.addChildTransactions(c);
+            }
+        }
+        return b.build();
     }
 
     // ---------- internals ----------
 
     /** Walk items, group link UUIDs by as_of, fire one batched GetByIds per
-     * bucket, populate {@link LinkCache#SECURITY}. */
+     * bucket, populate {@link LinkCache#SECURITY}. Used by the
+     * Price → Security path; the Transaction path
+     * collects directly into a {@link SecurityProto} list (which lets it
+     * cover {@code child_transactions[i].security} too — second-brain#348) and
+     * calls {@link #ensureSecurityLinksCached(Collection)}. */
     private <T> void ensureSecuritiesCached(
             List<T> items,
             java.util.function.Predicate<T> hasSec,
             java.util.function.Function<T, SecurityProto> getSec) {
-        // bucketKey -> uuid -> uuid (deduped) for that as_of
-        Map<String, Map<UUID, UUID>> buckets = new HashMap<>();
-        Map<String, LocalTimestampProto> bucketAsOfs = new HashMap<>();
+        List<SecurityProto> links = new ArrayList<>(items.size());
         for (T item : items) {
             if (!hasSec.test(item)) continue;
             SecurityProto sec = getSec.apply(item);
+            if (sec.getIsLink()) links.add(sec);
+        }
+        ensureSecurityLinksCached(links);
+    }
+
+    /** Bucket the given link-mode SecurityProtos by as_of, fire one batched
+     * GetByIds per bucket, populate {@link LinkCache#SECURITY}. Items that
+     * are already cached for a (uuid, as_of) are skipped. */
+    private void ensureSecurityLinksCached(Collection<SecurityProto> links) {
+        // bucketKey -> uuid -> uuid (deduped) for that as_of
+        Map<String, Map<UUID, UUID>> buckets = new HashMap<>();
+        Map<String, LocalTimestampProto> bucketAsOfs = new HashMap<>();
+        for (SecurityProto sec : links) {
             if (!sec.getIsLink()) continue;
             UUID uuid = ProtoSerializationUtil.deserializeUUID(sec.getUuid());
             LocalTimestampProto asOf = sec.hasAsOf() ? sec.getAsOf() : null;
@@ -284,13 +424,11 @@ public class LinkResolver {
         }
     }
 
-    /** Same as ensureSecuritiesCached but for Transaction.portfolio. */
-    private void ensurePortfoliosCached(List<TransactionProto> items) {
+    /** Portfolio counterpart to {@link #ensureSecurityLinksCached(Collection)}. */
+    private void ensurePortfolioLinksCached(Collection<PortfolioProto> links) {
         Map<String, Map<UUID, UUID>> buckets = new HashMap<>();
         Map<String, LocalTimestampProto> bucketAsOfs = new HashMap<>();
-        for (TransactionProto t : items) {
-            if (!t.hasPortfolio()) continue;
-            PortfolioProto port = t.getPortfolio();
+        for (PortfolioProto port : links) {
             if (!port.getIsLink()) continue;
             UUID uuid = ProtoSerializationUtil.deserializeUUID(port.getUuid());
             LocalTimestampProto asOf = port.hasAsOf() ? port.getAsOf() : null;

--- a/ledger-models-java/src/test/java/common/util/LinkResolverTest.java
+++ b/ledger-models-java/src/test/java/common/util/LinkResolverTest.java
@@ -502,4 +502,385 @@ class LinkResolverTest {
         assertEquals("BULK", fromLinkCache.getIssuerName());
         LinkCache.SECURITY.clear();
     }
+
+    // ---------- second-brain#348 — child-transaction Security hydration ----------
+    //
+    // Pre-fix: resolveSecuritiesOnTransactions only walked the top-level
+    // `security` field on each TransactionProto. After Transaction.getProto()
+    // strip-on-write (Phase 2 #340) the CHILDREN (cash-impact WITHDRAWAL,
+    // derived MATURATION, MATURATION's DEPOSIT) also carried link-mode
+    // securities. Consumers reading child.getSecurity() got a base Security
+    // wrapper — broke the (BondSecurity) cast at
+    // ledger-service TaxLotCalculator.java:61 with ClassCastException, which
+    // surfaced as Phase 4's 1,209 / 6,857 Transaction.CreateOrUpdate
+    // rejections (StatusCode.UNKNOWN: Application error processing RPC).
+    //
+    // These tests pin the new contract: every link-mode security in the
+    // forest — top-level, every child, recursively — is hydrated by a single
+    // resolveSecuritiesOnTransactions call, batching across the whole tree.
+
+    private static SecurityProto fullBondSecurity(UUID uuid, String cusip) {
+        // TBILL-shape with bond_details so downstream Security.fromProto
+        // dispatches to BondSecurity (the cast site we're protecting).
+        return SecurityProto.newBuilder()
+                .setObjectClass("Security")
+                .setVersion("0.0.1")
+                .setUuid(uuidProto(uuid))
+                .setIsLink(false)
+                .setIssuerName("US TREASURY")
+                .setProductType(fintekkers.models.security.ProductTypeProto.TBILL)
+                .addIdentifiers(IdentifierProto.newBuilder()
+                        .setIdentifierType(fintekkers.models.security.IdentifierTypeProto.CUSIP)
+                        .setIdentifierValue(cusip).build())
+                .setBondDetails(fintekkers.models.security.BondDetailsProto.newBuilder()
+                        .setIssueDate(fintekkers.models.util.LocalDate.LocalDateProto.newBuilder()
+                                .setYear(2023).setMonth(5).setDay(16).build())
+                        .setDatedDate(fintekkers.models.util.LocalDate.LocalDateProto.newBuilder()
+                                .setYear(2023).setMonth(5).setDay(16).build())
+                        .setMaturityDate(fintekkers.models.util.LocalDate.LocalDateProto.newBuilder()
+                                .setYear(2023).setMonth(9).setDay(12).build())
+                        .build())
+                .build();
+    }
+
+    private static SecurityProto fullCashSecurity(UUID uuid) {
+        return SecurityProto.newBuilder()
+                .setObjectClass("Security")
+                .setVersion("0.0.1")
+                .setUuid(uuidProto(uuid))
+                .setIsLink(false)
+                .setIssuerName("USD")
+                .setProductType(fintekkers.models.security.ProductTypeProto.CURRENCY)
+                .setCashDetails(fintekkers.models.security.CashDetailsProto.newBuilder()
+                        .setCashId("USD").build())
+                .build();
+    }
+
+    /** Build a Transaction tree shaped like a SOMA Treasury BUY after
+     *  addCashImpact + addDerivedTransactions ran server-side and then
+     *  Transaction.getProto() applied strip-on-write to everything inside:
+     *
+     *      BUY (bond LINK)
+     *      ├── WITHDRAWAL (cash LINK)
+     *      └── MATURATION (bond LINK)
+     *          └── DEPOSIT (cash LINK)
+     *
+     *  This is the exact wire shape that hit
+     *  TaxLotCalculator.java:61's (BondSecurity) cast and threw
+     *  ClassCastException on the MATURATION child (second-brain#348).
+     */
+    private TransactionProto somaTreasuryChain_allLinkMode(UUID bondUuid, UUID cashUuid) {
+        SecurityProto bondLink = linkSecurity(bondUuid);
+        SecurityProto cashLink = linkSecurity(cashUuid);
+
+        TransactionProto deposit = TransactionProto.newBuilder()
+                .setObjectClass("Transaction").setVersion("0.0.1")
+                .setUuid(uuidProto(UUID.randomUUID()))
+                .setSecurity(cashLink)
+                .setTransactionType(fintekkers.models.transaction.TransactionTypeProto.DEPOSIT)
+                .build();
+        TransactionProto maturation = TransactionProto.newBuilder()
+                .setObjectClass("Transaction").setVersion("0.0.1")
+                .setUuid(uuidProto(UUID.randomUUID()))
+                .setSecurity(bondLink)
+                .setTransactionType(fintekkers.models.transaction.TransactionTypeProto.MATURATION)
+                .addChildTransactions(deposit)
+                .build();
+        TransactionProto withdrawal = TransactionProto.newBuilder()
+                .setObjectClass("Transaction").setVersion("0.0.1")
+                .setUuid(uuidProto(UUID.randomUUID()))
+                .setSecurity(cashLink)
+                .setTransactionType(fintekkers.models.transaction.TransactionTypeProto.WITHDRAWAL)
+                .build();
+        return TransactionProto.newBuilder()
+                .setObjectClass("Transaction").setVersion("0.0.1")
+                .setUuid(uuidProto(UUID.randomUUID()))
+                .setSecurity(bondLink)
+                .setTransactionType(fintekkers.models.transaction.TransactionTypeProto.BUY)
+                .addChildTransactions(withdrawal)
+                .addChildTransactions(maturation)
+                .build();
+    }
+
+    @Test
+    void issue348_childTransactionSecurities_areHydratedByBulkResolve() {
+        LinkCache.SECURITY.clear();
+        UUID bondUuid = UUID.randomUUID();
+        UUID cashUuid = UUID.randomUUID();
+        Map<String, SecurityProto> store = Map.of(
+                bondUuid.toString(), fullBondSecurity(bondUuid, "912797GS0"),
+                cashUuid.toString(), fullCashSecurity(cashUuid));
+        RecordingSecurityFetcher fetcher = new RecordingSecurityFetcher(new HashMap<>(store));
+        LinkResolver resolver = new LinkResolver(fetcher,
+                req -> { throw new IllegalStateException("portfolio fetcher should not be called"); });
+
+        TransactionProto buy = somaTreasuryChain_allLinkMode(bondUuid, cashUuid);
+        List<TransactionProto> out = resolver.resolveSecuritiesOnTransactions(List.of(buy));
+
+        TransactionProto hydratedBuy = out.get(0);
+
+        // Top-level BUY: bond hydrated.
+        assertFalse(hydratedBuy.getSecurity().getIsLink(),
+                "Top-level BUY's security must be hydrated");
+        assertEquals(fintekkers.models.security.ProductTypeProto.TBILL,
+                hydratedBuy.getSecurity().getProductType(),
+                "Hydrated bond must carry a concrete productType so Security.fromProto dispatches to BondSecurity");
+
+        // Every child's security: also hydrated. This is the exact contract
+        // that was broken pre-#348.
+        assertEquals(2, hydratedBuy.getChildTransactionsCount());
+        TransactionProto withdrawal = hydratedBuy.getChildTransactions(0);
+        TransactionProto maturation = hydratedBuy.getChildTransactions(1);
+
+        assertFalse(withdrawal.getSecurity().getIsLink(),
+                "WITHDRAWAL (cash leg) security must be hydrated");
+        assertEquals(fintekkers.models.security.ProductTypeProto.CURRENCY,
+                withdrawal.getSecurity().getProductType());
+
+        assertFalse(maturation.getSecurity().getIsLink(),
+                "MATURATION child's security must be hydrated — this is the cast site that blew up #348");
+        assertEquals(fintekkers.models.security.ProductTypeProto.TBILL,
+                maturation.getSecurity().getProductType(),
+                "MATURATION child must carry TBILL productType so (BondSecurity) cast at "
+                        + "TaxLotCalculator.java:61 succeeds");
+
+        // Grandchild (MATURATION's DEPOSIT cash leg): also hydrated.
+        assertEquals(1, maturation.getChildTransactionsCount());
+        TransactionProto deposit = maturation.getChildTransactions(0);
+        assertFalse(deposit.getSecurity().getIsLink(),
+                "DEPOSIT grandchild (MATURATION's cash leg) security must be hydrated");
+        assertEquals(fintekkers.models.security.ProductTypeProto.CURRENCY,
+                deposit.getSecurity().getProductType());
+
+        LinkCache.SECURITY.clear();
+    }
+
+    @Test
+    void issue348_bulkResolve_batchesAcrossTreeInSingleRpc() {
+        LinkCache.SECURITY.clear();
+        UUID bondUuid = UUID.randomUUID();
+        UUID cashUuid = UUID.randomUUID();
+        Map<String, SecurityProto> store = Map.of(
+                bondUuid.toString(), fullBondSecurity(bondUuid, "912797GS0"),
+                cashUuid.toString(), fullCashSecurity(cashUuid));
+        RecordingSecurityFetcher fetcher = new RecordingSecurityFetcher(new HashMap<>(store));
+        LinkResolver resolver = new LinkResolver(fetcher,
+                req -> { throw new IllegalStateException("portfolio fetcher should not be called"); });
+
+        TransactionProto buy = somaTreasuryChain_allLinkMode(bondUuid, cashUuid);
+        // 5 link-mode security sub-protos across the tree (BUY+MATURATION on
+        // bond × 2, WITHDRAWAL+DEPOSIT on cash × 2 — wait, BUY has bondLink,
+        // WITHDRAWAL cashLink, MATURATION bondLink, DEPOSIT cashLink = 4 link
+        // refs total, but only 2 unique UUIDs). The resolver must dedupe
+        // across the forest and fire exactly one RPC.
+        resolver.resolveSecuritiesOnTransactions(List.of(buy));
+
+        assertEquals(1, fetcher.callCount,
+                "All link-mode securities in the tree should be fetched in a single batched RPC");
+        assertEquals(2, fetcher.requestedUuids.get(0).size(),
+                "Two unique UUIDs (bond + cash) requested in the batch");
+        Set<String> requested = new HashSet<>(fetcher.requestedUuids.get(0));
+        assertEquals(Set.of(bondUuid.toString(), cashUuid.toString()), requested);
+
+        LinkCache.SECURITY.clear();
+    }
+
+    @Test
+    void issue348_alreadyFullSecuritiesOnChildren_passThrough() {
+        // Defensive: if the producer happens to send a Transaction whose
+        // child carries a full inline security (no strip-on-write applied),
+        // the resolver must leave it alone and never make any RPC.
+        LinkCache.SECURITY.clear();
+        UUID bondUuid = UUID.randomUUID();
+        UUID cashUuid = UUID.randomUUID();
+        RecordingSecurityFetcher fetcher = new RecordingSecurityFetcher(new HashMap<>());
+        LinkResolver resolver = new LinkResolver(fetcher,
+                req -> { throw new IllegalStateException("portfolio fetcher should not be called"); });
+
+        SecurityProto fullBond = fullBondSecurity(bondUuid, "912797GS0");
+        SecurityProto fullCash = fullCashSecurity(cashUuid);
+
+        TransactionProto maturation = TransactionProto.newBuilder()
+                .setObjectClass("Transaction").setVersion("0.0.1")
+                .setUuid(uuidProto(UUID.randomUUID()))
+                .setSecurity(fullBond)
+                .setTransactionType(fintekkers.models.transaction.TransactionTypeProto.MATURATION)
+                .build();
+        TransactionProto buy = TransactionProto.newBuilder()
+                .setObjectClass("Transaction").setVersion("0.0.1")
+                .setUuid(uuidProto(UUID.randomUUID()))
+                .setSecurity(fullBond)
+                .setTransactionType(fintekkers.models.transaction.TransactionTypeProto.BUY)
+                .addChildTransactions(maturation)
+                .build();
+
+        List<TransactionProto> out = resolver.resolveSecuritiesOnTransactions(List.of(buy));
+
+        assertEquals(0, fetcher.callCount, "No link-mode → no RPC");
+        // Reference-identity pass-through is a perf optimization, not a
+        // contract. Assert observable: still a TBILL bond on both nodes.
+        assertEquals(fintekkers.models.security.ProductTypeProto.TBILL,
+                out.get(0).getSecurity().getProductType());
+        assertEquals(fintekkers.models.security.ProductTypeProto.TBILL,
+                out.get(0).getChildTransactions(0).getSecurity().getProductType());
+        // Cash sentinel not needed for this scenario; ensure unused fields
+        // are quiet.
+        assertEquals(0, fullCash.getIsLink() ? 1 : 0);
+
+        LinkCache.SECURITY.clear();
+    }
+
+    @Test
+    void issue348_mixedTree_someChildrenLinkSomeFull_isHandled() {
+        // Edge case: a producer that sends the parent full but children
+        // stripped (or vice-versa). The resolver must hydrate ONLY the
+        // link-mode ones.
+        LinkCache.SECURITY.clear();
+        UUID bondUuid = UUID.randomUUID();
+        UUID cashUuid = UUID.randomUUID();
+        SecurityProto fullCash = fullCashSecurity(cashUuid);
+        SecurityProto bondLink = linkSecurity(bondUuid);
+
+        Map<String, SecurityProto> store = Map.of(
+                bondUuid.toString(), fullBondSecurity(bondUuid, "912797GS0"));
+        RecordingSecurityFetcher fetcher = new RecordingSecurityFetcher(new HashMap<>(store));
+        LinkResolver resolver = new LinkResolver(fetcher,
+                req -> { throw new IllegalStateException("portfolio fetcher should not be called"); });
+
+        TransactionProto withdrawal = TransactionProto.newBuilder()
+                .setObjectClass("Transaction").setVersion("0.0.1")
+                .setUuid(uuidProto(UUID.randomUUID()))
+                .setSecurity(fullCash)  // full
+                .setTransactionType(fintekkers.models.transaction.TransactionTypeProto.WITHDRAWAL)
+                .build();
+        TransactionProto maturation = TransactionProto.newBuilder()
+                .setObjectClass("Transaction").setVersion("0.0.1")
+                .setUuid(uuidProto(UUID.randomUUID()))
+                .setSecurity(bondLink)  // link
+                .setTransactionType(fintekkers.models.transaction.TransactionTypeProto.MATURATION)
+                .build();
+        TransactionProto buy = TransactionProto.newBuilder()
+                .setObjectClass("Transaction").setVersion("0.0.1")
+                .setUuid(uuidProto(UUID.randomUUID()))
+                .setSecurity(bondLink)  // link
+                .setTransactionType(fintekkers.models.transaction.TransactionTypeProto.BUY)
+                .addChildTransactions(withdrawal)
+                .addChildTransactions(maturation)
+                .build();
+
+        List<TransactionProto> out = resolver.resolveSecuritiesOnTransactions(List.of(buy));
+
+        assertEquals(1, fetcher.callCount, "Single RPC for the one unique link UUID");
+        assertEquals(1, fetcher.requestedUuids.get(0).size(),
+                "Only the bond UUID needs fetching — full cash sub-proto passes through");
+
+        TransactionProto h = out.get(0);
+        assertFalse(h.getSecurity().getIsLink());
+        assertEquals(fintekkers.models.security.ProductTypeProto.TBILL,
+                h.getSecurity().getProductType());
+        assertEquals(fintekkers.models.security.ProductTypeProto.CURRENCY,
+                h.getChildTransactions(0).getSecurity().getProductType());
+        assertFalse(h.getChildTransactions(1).getSecurity().getIsLink());
+        assertEquals(fintekkers.models.security.ProductTypeProto.TBILL,
+                h.getChildTransactions(1).getSecurity().getProductType());
+
+        LinkCache.SECURITY.clear();
+    }
+
+    @Test
+    void issue348_endToEnd_childMaturationGetSecurityReturnsBondSecurity_notBaseSecurity() {
+        // The whole point of this fix: after recursive hydration, wrapping
+        // the hydrated proto in a Transaction and calling getSecurity() on
+        // the MATURATION child must return a BondSecurity (not a base
+        // Security), so the (BondSecurity) cast at
+        // ledger-service TaxLotCalculator.java:61 succeeds.
+        //
+        // Pre-fix this exact call returned a base Security and threw
+        // ClassCastException at the cast site (#348 production failure).
+        LinkCache.SECURITY.clear();
+        UUID bondUuid = UUID.randomUUID();
+        UUID cashUuid = UUID.randomUUID();
+        Map<String, SecurityProto> store = Map.of(
+                bondUuid.toString(), fullBondSecurity(bondUuid, "912797GS0"),
+                cashUuid.toString(), fullCashSecurity(cashUuid));
+        RecordingSecurityFetcher fetcher = new RecordingSecurityFetcher(new HashMap<>(store));
+        LinkResolver resolver = new LinkResolver(fetcher,
+                req -> { throw new IllegalStateException("portfolio fetcher should not be called"); });
+
+        TransactionProto buyProto = somaTreasuryChain_allLinkMode(bondUuid, cashUuid);
+        TransactionProto hydrated = resolver.resolveSecuritiesOnTransactions(List.of(buyProto)).get(0);
+
+        // Wrap and traverse via the SAME path TaxLotCalculator takes.
+        common.models.transaction.Transaction buy =
+                new common.models.transaction.Transaction(hydrated);
+        assertEquals(2, buy.getChildTransactions().size());
+        common.models.transaction.Transaction maturation = buy.getChildTransactions().get(1);
+        assertEquals(fintekkers.models.transaction.TransactionTypeProto.MATURATION.name(),
+                maturation.getTransactionType().name());
+
+        // The contract-pinning assertion. This object reference must be a
+        // BondSecurity for ledger-service's `(BondSecurity) txn.getSecurity()`
+        // to work. Before the recursion fix this returned a base
+        // common.models.security.Security → ClassCastException at runtime.
+        common.models.security.Security maturationSec = maturation.getSecurity();
+        assertNotNull(maturationSec);
+        assertTrue(maturationSec instanceof common.models.security.BondSecurity,
+                "MATURATION child's getSecurity() must dispatch to BondSecurity. "
+                        + "Got: " + maturationSec.getClass().getName()
+                        + " — second-brain#348 reproduction guard.");
+
+        // And the (BondSecurity) cast must actually succeed.
+        common.models.security.BondSecurity bondCast =
+                (common.models.security.BondSecurity) maturationSec;
+        assertEquals(java.time.LocalDate.of(2023, 9, 12), bondCast.getMaturityDate());
+
+        LinkCache.SECURITY.clear();
+    }
+
+    @Test
+    void issue348_portfoliosOnChildren_areHydratedRecursively() {
+        // Portfolio counterpart: addCashImpact / addDerivedTransactions
+        // propagate parent's portfolio onto every child, and strip-on-write
+        // turns all of them into links. The recursive Portfolio hydration
+        // must mirror the Security path.
+        LinkCache.PORTFOLIO.clear();
+        UUID portUuid = UUID.randomUUID();
+        PortfolioProto fullPort = fullPortfolio(portUuid, "Federal Reserve SOMA Holdings");
+        Map<String, PortfolioProto> store = Map.of(portUuid.toString(), fullPort);
+        RecordingPortfolioFetcher fetcher = new RecordingPortfolioFetcher(new HashMap<>(store));
+        LinkResolver resolver = new LinkResolver(
+                req -> { throw new IllegalStateException("security fetcher should not be called"); },
+                fetcher);
+
+        PortfolioProto portLink = PortfolioProto.newBuilder()
+                .setUuid(uuidProto(portUuid))
+                .setIsLink(true).build();
+
+        TransactionProto maturation = TransactionProto.newBuilder()
+                .setObjectClass("Transaction").setVersion("0.0.1")
+                .setUuid(uuidProto(UUID.randomUUID()))
+                .setPortfolio(portLink)
+                .setTransactionType(fintekkers.models.transaction.TransactionTypeProto.MATURATION)
+                .build();
+        TransactionProto buy = TransactionProto.newBuilder()
+                .setObjectClass("Transaction").setVersion("0.0.1")
+                .setUuid(uuidProto(UUID.randomUUID()))
+                .setPortfolio(portLink)
+                .setTransactionType(fintekkers.models.transaction.TransactionTypeProto.BUY)
+                .addChildTransactions(maturation)
+                .build();
+
+        List<TransactionProto> out = resolver.resolvePortfoliosOnTransactions(List.of(buy));
+
+        assertEquals(1, fetcher.callCount, "Single batched RPC for the deduped portfolio UUID across the tree");
+        TransactionProto h = out.get(0);
+        assertFalse(h.getPortfolio().getIsLink(), "Top-level portfolio hydrated");
+        assertEquals("Federal Reserve SOMA Holdings", h.getPortfolio().getPortfolioName());
+        assertFalse(h.getChildTransactions(0).getPortfolio().getIsLink(),
+                "Child MATURATION's portfolio hydrated — recursive contract");
+        assertEquals("Federal Reserve SOMA Holdings",
+                h.getChildTransactions(0).getPortfolio().getPortfolioName());
+
+        LinkCache.PORTFOLIO.clear();
+    }
 }


### PR DESCRIPTION
## Summary
- Phase 4 of the fresh AWS deploy hit `StatusCode.UNKNOWN` on **1,209 / 6,857** `Transaction.CreateOrUpdate` calls — every failure was the same `ClassCastException` at `ledger-service` `position/engine/processor/TaxLotCalculator.java:61` (`(BondSecurity) txn.getSecurity()` inside the MATURATION case).
- Root cause: `Transaction.getProto()` strip-on-write (Phase 2 #340) turns **every** nested Security on a Transaction tree into a link-mode reference — top-level, the BUY's cash-impact WITHDRAWAL, the derived MATURATION, the MATURATION's DEPOSIT — but `LinkResolver.resolveSecuritiesOnTransactions` only hydrated the **top-level** `security` field. Child securities stayed as links, `Security.fromProto(linkProto)` returned base `Security` (`Security.java:190`), and the unconditional `(BondSecurity)` cast at the calculator blew up.
- Fix: walk the entire Transaction forest recursively in both phases of `resolveSecuritiesOnTransactions` and `resolvePortfoliosOnTransactions`. API surface unchanged.

## Change shape
- `ledger-models-java/src/main/java/common/util/LinkResolver.java` — both bulk hydrators now (1) collect link-mode sub-protos across top-level + every descendant, batch by `as_of`, fire one `GetByIds` per bucket via the same dedup contract; (2) rebuild each tree recursively, swapping link-mode → resolved while preserving reference-identity pass-through when nothing changed. Helper `ensureSecurityLinksCached(Collection<SecurityProto>)` + portfolio counterpart extracted from the old per-item helper so both old (Price → Security) and new (Transaction tree → Security) paths share batching.
- `ledger-models-java/src/test/java/common/util/LinkResolverTest.java` — 6 new tests pin the new contract (see "Tests" below).
- API signatures unchanged. Existing callers (`Service.java` startup replay; any future `TransactionAPIGRPCImpl` integration) get child hydration for free.

## Tests (per processes/testing.md)

### Targeted (LinkResolverTest)
```
$ cd ~/projects/ledger-models/ledger-models-java
$ JAVA_HOME="/opt/homebrew/opt/openjdk@17" ./gradlew test --tests 'common.util.LinkResolverTest'

tests=21 failures=0 errors=0
  issue348_endToEnd_childMaturationGetSecurityReturnsBondSecurity_notBaseSecurity()  PASSED   ← the production-failure repro
  issue348_childTransactionSecurities_areHydratedByBulkResolve()                     PASSED
  issue348_bulkResolve_batchesAcrossTreeInSingleRpc()                                PASSED
  issue348_mixedTree_someChildrenLinkSomeFull_isHandled()                            PASSED
  issue348_alreadyFullSecuritiesOnChildren_passThrough()                             PASSED
  issue348_portfoliosOnChildren_areHydratedRecursively()                             PASSED
  (15 pre-existing LinkResolver tests)                                               PASSED
```

The `issue348_endToEnd_…` test is the closest possible repro: it builds the exact SOMA Treasury BUY shape (`BUY → [WITHDRAWAL, MATURATION → [DEPOSIT]]` with link-mode securities everywhere), runs it through the resolver, wraps the hydrated proto in a `Transaction`, and asserts:

```java
common.models.security.Security maturationSec = maturation.getSecurity();
assertTrue(maturationSec instanceof common.models.security.BondSecurity,
        "MATURATION child's getSecurity() must dispatch to BondSecurity. "
        + "Got: " + maturationSec.getClass().getName()
        + " — second-brain#348 reproduction guard.");

common.models.security.BondSecurity bondCast =
        (common.models.security.BondSecurity) maturationSec;          // ← the exact cast from TaxLotCalculator.java:61
assertEquals(java.time.LocalDate.of(2023, 9, 12), bondCast.getMaturityDate());
```

Pre-fix this assertion would have failed (`maturationSec` would be a base `common.models.security.Security` and the cast would throw `ClassCastException`).

### Full backwards-compat suite
```
$ JAVA_HOME="/opt/homebrew/opt/openjdk@17" ./gradlew clean test

TOTAL: tests=226 passed=226 failed=0 errored=0 skipped=0
```

Zero regressions. The previously-existing tests cover the API shape and per-call dedup invariants the new code preserves.

## Blast radius
- **API surface unchanged.** `resolveSecuritiesOnTransactions` / `resolvePortfoliosOnTransactions` keep their `List<TransactionProto> → List<TransactionProto>` signatures. Every existing caller automatically picks up child hydration without any code change.
- **Dispatch contract unchanged.** `Security.fromProto` still returns base `Security` for link-mode protos; the fix prevents link-mode protos from reaching that dispatch in the first place via the upstream resolver.
- **RPC count is monotonically ≤ the previous count.** The new path batches the whole forest into the same per-bucket `GetByIds` call (dedup by `(uuid, as_of)` against the process-wide `LinkCache`). A tree of N securities still costs at most one bucketed RPC for unique (uuid, as_of) misses.
- **Reference-identity preserved** on the no-rewrite path: if no link-mode entity is present in a Transaction tree, the input proto is returned unchanged (`==`-equal), so callers doing identity comparisons keep working.

## Coordination
- Companion consumer audit posted on `FinTekkers/second-brain#348` — covers ledger-service + ledger-models call sites that read Transaction.getSecurity() / child.getSecurity() without prior hydration. None of them need code changes once this merges (callers route through the resolver before processing).
- **NOT for autonomous merge** — PM/user must sign off before the ledger redeploy. This is the position engine's hot path; one regression in TaxLotCalculator processing breaks SOMA reload + every Treasury BUY.

🤖 Generated with [Claude Code](https://claude.com/claude-code)